### PR TITLE
Tracking Only -- Will not be merging directly -- cmdline updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
+/private
+
 build/**
 build_*/**
 .vscode/**
 .env
-
 src/translation/history/new__en-us.json

--- a/hacks/rtt_debugging.md
+++ b/hacks/rtt_debugging.md
@@ -100,18 +100,12 @@ This requires a pre-release version of OpenOCD 0.12.0
 <details><summary>As a single script...</summary><P/>
 
 ```
-reset halt
-rtt stop
-program /home/henrygab/bp5/build_rp2350/src/bus_pirate6.elf
-reset halt
-rp2350.dap.core1 arp_reset assert 0
-rp2350.dap.core0 arp_reset assert 0
-sleep 500
-rtt setup 0x20000000 0x100000 "SEGGER RTT"
-rtt start
+reset halt; program /home/henrygab/bp5/build_rp2350/src/bus_pirate6.elf
+reset halt; rp2350.dap.core1 arp_reset assert 0; rp2350.dap.core0 arp_reset assert 0; sleep 500; rtt setup 0x20000000 0x100000 "SEGGER RTT"; rtt start; rtt server start 4321 0
 
-rtt server start 4321 0
 
+reset halt; rtt stop; program /home/henrygab/bp5/build_rp2350/src/bus_pirate6.elf
+reset halt; rp2350.dap.core1 arp_reset assert 0; rp2350.dap.core0 arp_reset assert 0; sleep 500; rtt setup 0x20000000 0x100000 "SEGGER RTT"; rtt start
 ```
 
 </details>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,8 @@ set(buspirate_common
         commands/global/p_pullups.c
         commands/global/cmd_mcu.h
         commands/global/cmd_mcu.c
+        commands/global/cmd_comment.h
+        commands/global/cmd_comment.c
         commands/global/l_bitorder.h
         commands/global/l_bitorder.c
         commands/global/cmd_convert.h

--- a/src/command_struct.h
+++ b/src/command_struct.h
@@ -1,3 +1,6 @@
+#pragma once
+
+#include <stdint.h>
 #define MAX_COMMAND_LENGTH 10
 
 typedef struct command_result {

--- a/src/commands.c
+++ b/src/commands.c
@@ -56,7 +56,6 @@ const struct _global_command_struct commands[] = {
 { .command="m",         .allow_hiz=true,  .func=&ui_mode_enable_args,                .help_text=0x00 }, // "m"  T_CMDLN_MODE //needs trailing int32
 { .command="W",         .allow_hiz=false, .func=&psucmd_enable_handler,              .help_text=0x00 }, // "W"   T_CMDLN_PSU_EN  //TOD0: more flexability on help handling and also a general deescription
 { .command="reboot",    .allow_hiz=true,  .func=&cmd_mcu_reboot_handler,             .help_text=T_CMDLN_REBOOT }, // "reboot"
-{ .command="#",         .allow_hiz=true,  .func=&cmd_comment_handler,                .help_text=0x00 },
 { .command="$",         .allow_hiz=true,  .func=&cmd_mcu_jump_to_bootloader_handler, .help_text=0x00 }, // "$" T_CMDLN_BOOTLOAD
 { .command="=",         .allow_hiz=true,  .func=&cmd_convert_base_handler,           .help_text=T_CMDLN_INT_FORMAT }, // "="
 { .command="|",         .allow_hiz=true,  .func=&cmd_convert_inverse_handler,        .help_text=T_CMDLN_INT_INVERSE }, // "|"

--- a/src/commands.c
+++ b/src/commands.c
@@ -20,6 +20,7 @@
 #include "commands/global/p_pullups.h"
 #include "commands/global/cmd_mcu.h"
 #include "commands/global/l_bitorder.h"
+#include "commands/global/cmd_comment.h"
 #include "commands/global/cmd_convert.h"
 #include "commands/global/pause.h"
 #include "commands/global/h_help.h"
@@ -53,8 +54,9 @@ const struct _global_command_struct commands[] = {
 { .command="rm",        .allow_hiz=true,  .func=&disk_rm_handler,                    .help_text=0x00 }, // rm T_CMDLN_RM
 { .command="cat",       .allow_hiz=true,  .func=&disk_cat_handler,                   .help_text=0x00 }, // cat T_CMDLN_CAT
 { .command="m",         .allow_hiz=true,  .func=&ui_mode_enable_args,                .help_text=0x00 }, // "m"  T_CMDLN_MODE //needs trailing int32
-{ .command="W",         .allow_hiz=false, .func=&psucmd_enable_handler,              .help_text=0x00 }, // "W"   T_CMDLN_PSU_EN  //TODO: more flexibility on help handling and also a general deescription
+{ .command="W",         .allow_hiz=false, .func=&psucmd_enable_handler,              .help_text=0x00 }, // "W"   T_CMDLN_PSU_EN  //TOD0: more flexability on help handling and also a general deescription
 { .command="reboot",    .allow_hiz=true,  .func=&cmd_mcu_reboot_handler,             .help_text=T_CMDLN_REBOOT }, // "reboot"
+{ .command="#",         .allow_hiz=true,  .func=&cmd_comment_handler,                .help_text=0x00 },
 { .command="$",         .allow_hiz=true,  .func=&cmd_mcu_jump_to_bootloader_handler, .help_text=0x00 }, // "$" T_CMDLN_BOOTLOAD
 { .command="=",         .allow_hiz=true,  .func=&cmd_convert_base_handler,           .help_text=T_CMDLN_INT_FORMAT }, // "="
 { .command="|",         .allow_hiz=true,  .func=&cmd_convert_inverse_handler,        .help_text=T_CMDLN_INT_INVERSE }, // "|"

--- a/src/commands/global/cmd_comment.c
+++ b/src/commands/global/cmd_comment.c
@@ -137,7 +137,7 @@ static void hack_to_help_validate_command_line_parsing(uint32_t start_offset, ui
 }
 
 void cmd_comment_handler(uint32_t start_offset, uint32_t end_offset) {
-    cmdline_validate_invariants_command_line(&cmdln);
+    cmdline_validate_invariants(&cmdln);
 
     start_offset = cmdln_pu(start_offset + cmdln.read_offset);
     end_offset = cmdln_pu(end_offset + cmdln.read_offset);

--- a/src/commands/global/cmd_comment.c
+++ b/src/commands/global/cmd_comment.c
@@ -9,8 +9,31 @@
 
 
 void cmd_comment_handler(uint32_t start_offset, uint32_t end_offset) {
+    start_offset = cmdln_pu(start_offset + cmdln.read_offset);
+    end_offset = cmdln_pu(end_offset + cmdln.read_offset);
 
-    PRINT_DEBUG("cmd_comment_handler() - [%d .. %d]\r\n", start_offset, end_offset);
+    // Total hack:
+    if (start_offset == end_offset) {
+        PRINT_DEBUG("##\r\n");
+    } else if (start_offset < end_offset) {
+        char last_char = cmdln.buf[end_offset];
+        cmdln.buf[end_offset] = 0x00; // null-terminate the string
+        PRINT_DEBUG("#%s%c\r\n", &cmdln.buf[start_offset], last_char);
+        cmdln.buf[end_offset] = last_char; // restore the last character
+    } else {
+        char end_of_buffer_char = cmdln.buf[UI_CMDBUFFSIZE - 1];
+        char last_char = cmdln.buf[end_offset];
+        cmdln.buf[UI_CMDBUFFSIZE - 1] = 0x00; // null-terminate the first half of the string
+        cmdln.buf[end_offset] = 0x00; // null-terminate the second half of the string
+        PRINT_DEBUG(
+            "#%s%c%s%c\r\n",
+            &cmdln.buf[start_offset], end_of_buffer_char,
+            &cmdln.buf[0], last_char
+            );
+        cmdln.buf[UI_CMDBUFFSIZE - 1] = end_of_buffer_char; // restore the end of buffer character
+        cmdln.buf[end_offset] = last_char; // restore the last character
+    }
+
     // TODO: log the current command line (the comment) into the debug output stream
     //       This will make it easier to correlate other debug output with
     //       where in a long script (or macro, or other set of commands) that output
@@ -25,8 +48,5 @@ void cmd_comment_handler(uint32_t start_offset, uint32_t end_offset) {
     //  copy the last character of the command line buffer to a temporary variable
     //  set that last character to 0x00
     //  treat g_...[start_offset] as a null-terminated string
-
-    // PRINT_FATAL("CmdlineComment: %s", comment_command_line.buf);
-    // PRINT_INFO("CmdlineComment: %s", comment_command_line.buf);
     return;
 }

--- a/src/commands/global/cmd_comment.c
+++ b/src/commands/global/cmd_comment.c
@@ -7,25 +7,155 @@
 #include "ui/ui_cmdln.h"
 #include "string.h"
 
+// What is needed to declare the parameters?
+// List of parameters that the command would accept:
+// -h -- universal help flag (does not need to be declared)
+//
+// * bool positional_allowed
+// * char flag
+// * permitted data type(s)
+
+
+static void hack_to_help_validate_command_line_parsing(uint32_t start_offset, uint32_t end_offset) {
+
+    // The ultimate goal is to verify APIs act the same after changing the backend/underlying logic.
+
+    // # Comment lines that will successfully find corresponding flags:
+    // # -----------------------------------------
+    /*
+# -h finds flag 'h'
+# find flag -h
+# find 'x' with hex value 21845 -x 0x5555
+# and 'x' with bin value 43690 -x 0b1010101010101010
+# but `y` with string abc -y abc
+    */
+
+    // # Behavior that requires review:
+    // # -------------------------------
+    //
+    // # Next line should successfully find flag 'x' with value 1234,
+    // # but appears to error out because there's an earlier '-x' in single-quotes.
+    // # (??? this should not be detected as a flag ???)
+    //
+    // # find '-x' with dec value 1234 -x 1234
+    //
+    // # Next line should FAIL to find any flags, because the argument is
+    // # preceded by TWO dashes, not one.   Currently, all these ARE detected,
+    // # which appears to be a bug.
+    //
+    // # No flags --h --x 1234 --y abc
+    //
+    // # Why is getting positional item at index 6 as a string
+    // # returning a reformatted decimal value? (43690) instead
+    // # of the original binary value (0b1010101010101010)?
+    // # if intended to get reformatted value as string, perhaps
+    // # name the API accordingly?
+    //
+    // # and 'x' with bin value 43690 -x 0b1010101010101010
+    //
+
+
+
+    // # Comment lines that should NOT find flags:
+    // # -----------------------------------------
+    /*
+    */
+
+    // For validating the major changes, also call various functions (ignoring failures)
+
+    // finding flags by name
+    do { // cmdln_args_find_flag('h')
+        bool has_flag_h = cmdln_args_find_flag('h');
+
+        command_var_t x_value_stuff = {0};
+        uint32_t x_value = 0;
+        bool has_flag_value_x = cmdln_args_find_flag_uint32('x', &x_value_stuff, &x_value);
+
+        command_var_t y_value_stuff = {0};
+        char y_string[5] = {0};
+        bool has_flag_str_y = cmdln_args_find_flag_string('y', &y_value_stuff, 5, &y_string[0]);
+
+        PRINT_DEBUG( "cmd_comment_handler:   ret | err | x value (dec/hex)     | y str \r\n");
+        PRINT_DEBUG( "cmd_comment_handler:  -----|-----|-----------------------|-------\r\n");
+        PRINT_DEBUG( "cmd_comment_handler:   %c%c%c | %c%c%c | %10d / %08X | %s\r\n",
+            has_flag_h          ? 'H' : '.',
+            has_flag_value_x    ? 'X' : '.',
+            has_flag_str_y      ? 'Y' : '.',
+            has_flag_h          ? '.' : 'h',
+            x_value_stuff.error ? 'x' : '.',
+            y_value_stuff.error ? 'y' : '.',
+            (has_flag_value_x && x_value_stuff.has_value) ? x_value : 0,
+            (has_flag_value_x && x_value_stuff.has_value) ? x_value : 0,
+            (has_flag_str_y   && y_value_stuff.has_value) ? y_string : ""
+        );
+    } while(false);
+
+
+
+    // Then validate getting things by position...
+    // NOTE: here, limiting string to 5 characters for debug print purposes
+    PRINT_DEBUG( "cmd_comment_handler:   arg | UFS | uint32                | Float  | String\r\n");
+    PRINT_DEBUG( "cmd_comment_handler:   ----|-----|-----------------------|--------|--------\r\n");
+
+    do { // cmdln_args_string_by_position(0, ...)
+        for (int_fast8_t i = 0; i < 10; ++i) {
+            float vf = 0.0f;
+            char vfs[20] = {0};
+            uint32_t vi = 0;
+            char vs[6] = {0};
+            bool bf = cmdln_args_float_by_position(i, &vf);
+            bool bi = cmdln_args_uint32_by_position(i, &vi);
+            bool bs = cmdln_args_string_by_position(i, 6, &vs[0]);
+            if (bf) {
+                // RTT does not output float....
+                int written_chars = snprintf(&vfs[0], 20, "%f", vf);
+                if (written_chars >= 20) {
+                    vfs[0] = 'e';
+                    vfs[1] = 'r';
+                    vfs[2] = 'r';
+                    vfs[19] = 0x00; // null-terminate
+                }
+            }
+
+            // ( "cmd_comment_handler:     1 | UFS | 4294967295 / F7E6D5C4 | 10.374 |  xxxxx\r\n");
+            // ( "cmd_comment_handler:     1 | ... |          0 / 00000000 |  0     |  \r\n");
+            PRINT_DEBUG(
+                "cmd_comment_handler:   %3d | %c%c%c | %10d / %8X | %20s  |  %s\r\n",
+                i,
+                bi ? 'U' : '.',
+                bf ? 'F' : '.',
+                bs ? 'S' : '.',
+                bi ? vi : 0,
+                bi ? vi : 0,
+                bf ? vfs : "",
+                bs ? &vs[0] : ""
+            );
+        }
+
+    } while (false);
+    
+}
 
 void cmd_comment_handler(uint32_t start_offset, uint32_t end_offset) {
+    cmdline_validate_invariants_command_line(&cmdln);
+
     start_offset = cmdln_pu(start_offset + cmdln.read_offset);
     end_offset = cmdln_pu(end_offset + cmdln.read_offset);
 
-    // Total hack:
+    // Total printing hack (which can be removed when history is rotated after each command)
     if (start_offset == end_offset) {
-        PRINT_DEBUG("##\r\n");
+        PRINT_WARNING("##\r\n");
     } else if (start_offset < end_offset) {
         char last_char = cmdln.buf[end_offset];
         cmdln.buf[end_offset] = 0x00; // null-terminate the string
-        PRINT_DEBUG("#%s%c\r\n", &cmdln.buf[start_offset], last_char);
+        PRINT_WARNING("#%s%c\r\n", &cmdln.buf[start_offset], last_char);
         cmdln.buf[end_offset] = last_char; // restore the last character
     } else {
         char end_of_buffer_char = cmdln.buf[UI_CMDBUFFSIZE - 1];
         char last_char = cmdln.buf[end_offset];
         cmdln.buf[UI_CMDBUFFSIZE - 1] = 0x00; // null-terminate the first half of the string
         cmdln.buf[end_offset] = 0x00; // null-terminate the second half of the string
-        PRINT_DEBUG(
+        PRINT_WARNING(
             "#%s%c%s%c\r\n",
             &cmdln.buf[start_offset], end_of_buffer_char,
             &cmdln.buf[0], last_char
@@ -33,20 +163,7 @@ void cmd_comment_handler(uint32_t start_offset, uint32_t end_offset) {
         cmdln.buf[UI_CMDBUFFSIZE - 1] = end_of_buffer_char; // restore the end of buffer character
         cmdln.buf[end_offset] = last_char; // restore the last character
     }
+    hack_to_help_validate_command_line_parsing(start_offset, end_offset);
 
-    // TODO: log the current command line (the comment) into the debug output stream
-    //       This will make it easier to correlate other debug output with
-    //       where in a long script (or macro, or other set of commands) that output
-    //       was generated.
-
-    // start_offset is array index of start of the command in the global command line buffer
-    // end_offset   is array index of start of the command in the global command line buffer
-    // HOWEVER ... the command line buffer is used as a circular buffer, so these offsets
-    //       can NOT be used directly ... have to copy the command line to our own
-    //       buffer to ensure it's a single contiguous string.
-    // As a hack, if end_offset < start_offset, could...
-    //  copy the last character of the command line buffer to a temporary variable
-    //  set that last character to 0x00
-    //  treat g_...[start_offset] as a null-terminated string
     return;
 }

--- a/src/commands/global/cmd_comment.c
+++ b/src/commands/global/cmd_comment.c
@@ -1,0 +1,24 @@
+
+#define BP_DEBUG_OVERRIDE_DEFAULT_CATEGORY E_DEBUG_CAT_SCRIPT_COMMENTS
+
+#include "pirate.h"
+#include "cmd_comment.h"
+#include "stdbool.h"
+#include "ui/ui_cmdln.h"
+#include "string.h"
+
+void cmd_comment_handler(struct command_result* res) {
+
+    // TODO: log the current command line (the comment) into the debug output stream
+    // COPY_OF_COMMAND_LINE comment_command_line;
+    // retrieve_command_line_copy(&comment_command_line);
+    // PRINT_FATAL("CmdlineComment: %s", comment_command_line.buf);
+    // PRINT_INFO("CmdlineComment: %s", comment_command_line.buf);
+
+    res->success = true;
+    res->error = false;
+    res->exit = false;
+    res->no_value = true;
+    res->help_flag = false;
+    return;
+}

--- a/src/commands/global/cmd_comment.c
+++ b/src/commands/global/cmd_comment.c
@@ -7,20 +7,26 @@
 #include "ui/ui_cmdln.h"
 #include "string.h"
 
-void cmd_comment_handler(struct command_result* res) {
 
-    PRINT_DEBUG("cmd_comment_handler()\r\n");
+void cmd_comment_handler(uint32_t start_offset, uint32_t end_offset) {
 
+    PRINT_DEBUG("cmd_comment_handler() - [%d .. %d]\r\n", start_offset, end_offset);
     // TODO: log the current command line (the comment) into the debug output stream
-    // COPY_OF_COMMAND_LINE comment_command_line;
-    // retrieve_command_line_copy(&comment_command_line);
+    //       This will make it easier to correlate other debug output with
+    //       where in a long script (or macro, or other set of commands) that output
+    //       was generated.
+
+    // start_offset is array index of start of the command in the global command line buffer
+    // end_offset   is array index of start of the command in the global command line buffer
+    // HOWEVER ... the command line buffer is used as a circular buffer, so these offsets
+    //       can NOT be used directly ... have to copy the command line to our own
+    //       buffer to ensure it's a single contiguous string.
+    // As a hack, if end_offset < start_offset, could...
+    //  copy the last character of the command line buffer to a temporary variable
+    //  set that last character to 0x00
+    //  treat g_...[start_offset] as a null-terminated string
+
     // PRINT_FATAL("CmdlineComment: %s", comment_command_line.buf);
     // PRINT_INFO("CmdlineComment: %s", comment_command_line.buf);
-
-    res->success = true;
-    res->error = false;
-    res->exit = false;
-    res->no_value = true;
-    res->help_flag = false;
     return;
 }

--- a/src/commands/global/cmd_comment.c
+++ b/src/commands/global/cmd_comment.c
@@ -1,5 +1,5 @@
 
-#define BP_DEBUG_OVERRIDE_DEFAULT_CATEGORY E_DEBUG_CAT_SCRIPT_COMMENTS
+#define BP_DEBUG_OVERRIDE_DEFAULT_CATEGORY BP_DEBUG_CAT_CMD_COMMENTS
 
 #include "pirate.h"
 #include "cmd_comment.h"
@@ -8,6 +8,8 @@
 #include "string.h"
 
 void cmd_comment_handler(struct command_result* res) {
+
+    PRINT_DEBUG("cmd_comment_handler()\r\n");
 
     // TODO: log the current command line (the comment) into the debug output stream
     // COPY_OF_COMMAND_LINE comment_command_line;

--- a/src/commands/global/cmd_comment.h
+++ b/src/commands/global/cmd_comment.h
@@ -1,5 +1,5 @@
 #pragma once
 
-#include "command_struct.h"
+#include <stdint.h>
 
-void cmd_comment_handler(struct command_result* res);
+void cmd_comment_handler(uint32_t start_offset, uint32_t end_offset);

--- a/src/commands/global/cmd_comment.h
+++ b/src/commands/global/cmd_comment.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "command_struct.h"
+
+void cmd_comment_handler(struct command_result* res);

--- a/src/commands/global/macro.c
+++ b/src/commands/global/macro.c
@@ -112,11 +112,13 @@ static bool exec_macro_id(const char* id) {
     }
     m++;
 
-    // FIXME: injecting the bus syntax into cmd line (i.e. simulating
+    // BUGBUG -- injecting the bus syntax into cmd line (i.e. simulating
     // user input) is probably not the best solution... :-/
     // printf("Inject cmd\r\n");
     // TODO: there is a way to advance through the cmdln queue that leaves a history pointer so up and down work
     // I think instead of of reading to end, we need to advance to the next buffer position
+    // BETTER SOLUTION: `ui_process_syntax()` should be passed a pointer to the buffer to parse as a command line.
+    // Then, there's no need to interact with the cmdln queue at all.
     char c;
     while (cmdln_try_remove(&c))
         ;

--- a/src/commands/global/macro.c
+++ b/src/commands/global/macro.c
@@ -91,41 +91,48 @@ void macro_handler(struct command_result* res) {
 }
 
 static bool exec_macro_id(const char* id) {
-    char line[512];
+
+    command_line_history_t macro_history;
+    cmdln_init_command_history(&macro_history);
+
     printf("Exec macro id: %s\r\n", id);
 
-    disk_get_line_id(macro_file, id, line, sizeof(line));
-    if (!line[0]) {
+    disk_get_line_id(macro_file, id, &macro_history.buf[0], sizeof(macro_history.buf));
+    if (!macro_history.buf[0]) {
         printf("Macro not fund\r\n");
         return true;
     }
 
-    char* m = line;
+    // The macro line format is: <id>:<bus syntax>
+    // find the offset to the first character after the id and separator ':'
+    size_t starting_offset = 0;
+
     // Skip id and separator
     // 123:MACRO
-    while (*m && *m != ':') {
-        m++;
+    while (macro_history.buf[starting_offset] && macro_history.buf[starting_offset] != ':') {
+        starting_offset++;
+        if (starting_offset >= sizeof(macro_history.buf)-1) {
+            printf("Macro line too long\r\n");
+            return true; // BUGBUG -- should this return false, when the macro format is incorrect?  I think so!
+        }
     }
-    if (*m != ':') {
+    if (macro_history.buf[starting_offset] != ':') {
         printf("Wrong macro line format\r\n");
-        return true;
+        return true; // BUGBUG -- should this return false, when the macro format is incorrect?  I think so!
     }
-    m++;
+    starting_offset++; // skip the ':'
 
-    // BUGBUG -- injecting the bus syntax into cmd line (i.e. simulating
-    // user input) is probably not the best solution... :-/
-    // printf("Inject cmd\r\n");
-    // TODO: there is a way to advance through the cmdln queue that leaves a history pointer so up and down work
-    // I think instead of of reading to end, we need to advance to the next buffer position
-    // BETTER SOLUTION: `ui_process_syntax()` should be passed a pointer to the buffer to parse as a command line.
-    // Then, there's no need to interact with the cmdln queue at all.
-    char c;
-    while (cmdln_try_remove(&c))
-        ;
-    while (*m && cmdln_try_add(m)) {
-        m++;
+    uint32_t macro_len = strlen(&macro_history.buf[starting_offset]);
+    if (macro_len == 0) {
+        printf("Macro line empty\r\n");
+        return true; // BUGBUG -- should this return false, when the macro format is incorrect?  I think so!
     }
-    cmdln_try_add('\0');
+
+    // move that one string to the beginning of the buffer
+    memmove(&macro_history.buf[0], &macro_history.buf[starting_offset], macro_len);
+    // and then null-terminate the remainder
+    memset(&macro_history.buf[macro_len], 0, sizeof(macro_history.buf) - macro_len);
+    macro_history.write_offset = macro_len;
     // printf("Process syntax\r\n");
     return ui_process_syntax(); // I think we're going to run into issues with the ui_process loop if &&||; are used....
 }

--- a/src/commands/global/w_psu.c
+++ b/src/commands/global/w_psu.c
@@ -15,11 +15,11 @@
 
 const char* const psucmd_usage[] = {
     "w|W\t<v> <i>",
-    "Disable: w",
-    "Enable, with menu: W",
-    "Enable 5v, 50mA limit: W 5 50",
-    "Enable 3.3v, 300mA default limit: W 3.3",
-    "Enable 3.3v, no limit: W 3.3 0",
+    "Disable:                           w",
+    "Enable, with prompts:              W",
+    "Enable 5v, 50mA limit:             W 5 50",
+    "Enable 3.3v, 300mA default limit:  W 3.3",
+    "Enable 3.3v, no limit:             W 3.3 0",
 };
 
 const struct ui_help_options psucmd_options[] = {

--- a/src/debug_rtt.c
+++ b/src/debug_rtt.c
@@ -62,11 +62,13 @@ void hard_assertion_failure(void) {
     ( (uint32_t) (((uint32_t)1u) << _E_DEBUG_VALUE) )    
 
 uint32_t         _DEBUG_ENABLED_CATEGORIES = // mask of enabled debug categories
-    _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_CATCHALL)            |
-    _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_EARLY_BOOT)          |
-    // _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_ONBOARD_PIXELS)      |
-    _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_ONBOARD_STORAGE)     |
-    _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_TEMP)                |
+    _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_CATCHALL        ) |
+    _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_EARLY_BOOT      ) |
+    // _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_ONBOARD_PIXELS  ) |
+    _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_ONBOARD_STORAGE ) |
+    _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_CMD_COMMENTS    ) |
+    _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_CMDLINE_PARSER  ) |
+    _DEBUG_E_CAT_TO_MASK(E_DEBUG_CAT_TEMP            ) |
     0u;
 
 // If listed, will be initialized to the specified value.
@@ -78,6 +80,8 @@ bp_debug_level_t _DEBUG_LEVELS[32] = {
     [E_DEBUG_CAT_EARLY_BOOT     ] = BP_DEBUG_LEVEL_VERBOSE,
     [E_DEBUG_CAT_ONBOARD_PIXELS ] = BP_DEBUG_LEVEL_VERBOSE,
     [E_DEBUG_CAT_ONBOARD_STORAGE] = BP_DEBUG_LEVEL_VERBOSE,
+    [E_DEBUG_CAT_CMD_COMMENTS   ] = BP_DEBUG_LEVEL_DEBUG,
+    [E_DEBUG_CAT_CMDLINE_PARSER ] = BP_DEBUG_LEVEL_DEBUG,
     // add others here, in order of enumeration value
     [E_DEBUG_CAT_TEMP           ] = BP_DEBUG_LEVEL_DEBUG,
 }; // up to 32 categories, each with a debug level

--- a/src/debug_rtt.h
+++ b/src/debug_rtt.h
@@ -188,6 +188,7 @@ static inline bool bp_debug_should_print(bp_debug_level_t level, bp_debug_catego
 #define PRINT_INFO(...)
 #define PRINT_VERBOSE(...)
 #define PRINT_DEBUG(...)
+#define PRINT_NEVER(...)
 
 #else
 
@@ -197,6 +198,7 @@ static inline bool bp_debug_should_print(bp_debug_level_t level, bp_debug_catego
 #define PRINT_INFO(...)    BP_DEBUG_PRINT(BP_DEBUG_LEVEL_INFO,    BP_DEBUG_DEFAULT_CATEGORY, __VA_ARGS__)
 #define PRINT_VERBOSE(...) BP_DEBUG_PRINT(BP_DEBUG_LEVEL_VERBOSE, BP_DEBUG_DEFAULT_CATEGORY, __VA_ARGS__)
 #define PRINT_DEBUG(...)   BP_DEBUG_PRINT(BP_DEBUG_LEVEL_DEBUG,   BP_DEBUG_DEFAULT_CATEGORY, __VA_ARGS__)
+#define PRINT_NEVER(...)
 
 #endif
 

--- a/src/debug_rtt.h
+++ b/src/debug_rtt.h
@@ -37,7 +37,9 @@
         E_DEBUG_CAT_CATCHALL         =  0u, // (((uint32_t)1u) <<  0u), // for messages that are not (yet) categorized
         E_DEBUG_CAT_EARLY_BOOT       =  1u, // (((uint32_t)1u) <<  1u), // early-in-boot (initialization)
         E_DEBUG_CAT_ONBOARD_PIXELS   =  2u, // (((uint32_t)1u) <<  2u), // onboard RGB pixels
-        E_DEBUG_CAT_ONBOARD_STORAGE  =  3u, // (((uint32_t)1u) << XXu), // lcdi2c mode specific
+        E_DEBUG_CAT_ONBOARD_STORAGE  =  3u, // (((uint32_t)1u) <<  3u), // ???
+        E_DEBUG_CAT_CMD_COMMENTS     =  4u, // (((uint32_t)1u) <<  4u), // comments entered at command line (e.g., `# this is a comment`)
+        E_DEBUG_CAT_CMDLINE_PARSER   =  4u, // (((uint32_t)1u) <<  4u), // comments entered at command line (e.g., `# this is a comment`)
         // E_DEBUG_CAT_USB_HID          = XXu, // (((uint32_t)1u) << XXu), // USB based HID interactions
         // E_DEBUG_CAT_USB_CDC          = XXu, // (((uint32_t)1u) << XXu), // USB based serial port
         // E_DEBUG_CAT_USB_MSC          = XXu, // (((uint32_t)1u) << XXu), // USB based mass storage commands
@@ -95,7 +97,10 @@
 #define BP_DEBUG_CAT_CATCHALL         ((bp_debug_category_t){ E_DEBUG_CAT_CATCHALL         }) // for messages that are not (yet) categorized
 #define BP_DEBUG_CAT_EARLY_BOOT       ((bp_debug_category_t){ E_DEBUG_CAT_EARLY_BOOT       }) // early-in-boot (initialization)
 #define BP_DEBUG_CAT_ONBOARD_PIXELS   ((bp_debug_category_t){ E_DEBUG_CAT_ONBOARD_PIXELS   }) // onboard RGB pixels
-#define BP_DEBUG_CAT_ONBOARD_STORAGE  ((bp_debug_category_t){ E_DEBUG_CAT_ONBOARD_STORAGE  }) // onboard storage (e.g., to root cause FS corruption)
+#define BP_DEBUG_CAT_ONBOARD_STORAGE  ((bp_debug_category_t){ E_DEBUG_CAT_ONBOARD_STORAGE  }) // ???
+#define BP_DEBUG_CAT_CMD_COMMENTS     ((bp_debug_category_t){ E_DEBUG_CAT_CMD_COMMENTS     }) // comments entered at command line (e.g., `# this is a comment`)
+#define BP_DEBUG_CAT_CMDLINE_PARSER   ((bp_debug_category_t){ E_DEBUG_CAT_CMDLINE_PARSER   }) // Parsing of command line
+
 // #define BP_DEBUG_CAT_USB_HID          ((bp_debug_category_t){ E_DEBUG_CAT_USB_HID          }) // USB based HID interactions
 // #define BP_DEBUG_CAT_USB_CDC          ((bp_debug_category_t){ E_DEBUG_CAT_USB_CDC          }) // USB based serial port
 // #define BP_DEBUG_CAT_USB_MSC          ((bp_debug_category_t){ E_DEBUG_CAT_USB_MSC          }) // USB based mass storage commands

--- a/src/debug_rtt.h
+++ b/src/debug_rtt.h
@@ -39,7 +39,7 @@
         E_DEBUG_CAT_ONBOARD_PIXELS   =  2u, // (((uint32_t)1u) <<  2u), // onboard RGB pixels
         E_DEBUG_CAT_ONBOARD_STORAGE  =  3u, // (((uint32_t)1u) <<  3u), // ???
         E_DEBUG_CAT_CMD_COMMENTS     =  4u, // (((uint32_t)1u) <<  4u), // comments entered at command line (e.g., `# this is a comment`)
-        E_DEBUG_CAT_CMDLINE_PARSER   =  4u, // (((uint32_t)1u) <<  4u), // comments entered at command line (e.g., `# this is a comment`)
+        E_DEBUG_CAT_CMDLINE_PARSER   =  5u, // (((uint32_t)1u) <<  4u), // parsing of command line input
         // E_DEBUG_CAT_USB_HID          = XXu, // (((uint32_t)1u) << XXu), // USB based HID interactions
         // E_DEBUG_CAT_USB_CDC          = XXu, // (((uint32_t)1u) << XXu), // USB based serial port
         // E_DEBUG_CAT_USB_MSC          = XXu, // (((uint32_t)1u) << XXu), // USB based mass storage commands

--- a/src/displays.c
+++ b/src/displays.c
@@ -13,29 +13,31 @@
 #endif
 
 struct _display displays[MAXDISPLAY] = {
+    // clang-format off
     {
-        noperiodic,              // service to regular poll whether a byte ahs arrived
-        disp_default_setup,      // setup UI
-        disp_default_setup_exc,  // real setup
-        disp_default_cleanup,    // cleanup for HiZ
-        disp_default_settings,   // display settings
-        0,                       // display small help about the protocol
-        "Default",               // friendly name (promptname)
-        0,                       // scope specific commands
-        disp_default_lcd_update, // screen write
+        .display_periodic   = noperiodic,              // service to regular poll whether a byte ahs arrived
+        .display_setup      = disp_default_setup,      // setup UI
+        .display_setup_exc  = disp_default_setup_exc,  // real setup
+        .display_cleanup    = disp_default_cleanup,    // cleanup for HiZ
+        .display_settings   = disp_default_settings,   // display settings
+        .display_help       = 0,                       // display small help about the protocol
+        .display_name       = "Default",               // friendly name (promptname)
+        .display_command    = 0,                       // scope specific commands
+        .display_lcd_update = disp_default_lcd_update, // screen write
     },
 #ifdef BP_USE_SCOPE
     {
-        scope_periodic,   // service to regular poll whether a byte ahs arrived
-        scope_setup,      // setup UI
-        scope_setup_exc,  // real setup
-        scope_cleanup,    // cleanup for HiZ
-        scope_settings,   // display settings
-        scope_help,       // display small help about the protocol
-        "Scope",          // friendly name (promptname)
-        scope_commands,   // scope specific commands
-        scope_lcd_update, // scope screen write
+        .display_periodic   = scope_periodic,   // service to regular poll whether a byte ahs arrived
+        .display_setup      = scope_setup,      // setup UI
+        .display_setup_exc  = scope_setup_exc,  // real setup
+        .display_cleanup    = scope_cleanup,    // cleanup for HiZ
+        .display_settings   = scope_settings,   // display settings
+        .display_help       = scope_help,       // display small help about the protocol
+        .display_name       = "Scope",          // friendly name (promptname)
+        .display_command    = scope_commands,   // scope specific commands
+        .display_lcd_update = scope_lcd_update, // scope screen write
     },
+    // clang-format on
 #endif
 };
 /* For Emacs:

--- a/src/displays.h
+++ b/src/displays.h
@@ -11,15 +11,17 @@ enum {
 };
 
 typedef struct _display {
-    void (*display_periodic)(void);                             // regularly polled for events (byte arrival, etc.)
-    uint32_t (*display_setup)(void);                            // setup UI
-    uint32_t (*display_setup_exc)(void);                        // real setup
-    void (*display_cleanup)(void);                              // cleanup for HiZ
-    void (*display_settings)(void);                             // display settings
-    void (*display_help)(void);                                 // display protocol specific help
-    char display_name[10];                                      // friendly name (promptname)
-    uint32_t (*display_command)(struct command_result* result); // per mode command parser - ignored if 0
-    void (*display_lcd_update)(uint32_t flags);                 // replacement for ui_lcd_update if non-0
+    // clang-format off
+    void     (*display_periodic  )(void);                          // regularly polled for events (byte arrival, etc.)
+    uint32_t (*display_setup     )(void);                          // setup UI
+    uint32_t (*display_setup_exc )(void);                          // real setup
+    void     (*display_cleanup   )(void);                          // cleanup for HiZ
+    void     (*display_settings  )(void);                          // display settings
+    void     (*display_help      )(void);                          // display protocol specific help
+    char       display_name      [10];                             // friendly name (promptname)
+    uint32_t (*display_command   )(struct command_result* result); // per mode command parser - ignored if nullptr
+    void     (*display_lcd_update)(uint32_t flags);                // replacement for ui_lcd_update if non-nullptr
+    // clang-format on
 } _display;
 
 extern struct _display displays[MAXDISPLAY];

--- a/src/mode/LCDSPI.c
+++ b/src/mode/LCDSPI.c
@@ -16,29 +16,31 @@ static uint32_t currentdisplay;
 
 // subset of the protocol
 typedef struct _display {
-    uint32_t (*display_send)(uint32_t); // send max 32 bit
-    uint32_t (*display_read)(void);     // read max 32 bit (is thsi actually used?)
-    void (*display_macro)(uint32_t);    // macro
-    void (*display_setup)(void);        // setup UI
-    void (*display_cleanup)(void);      // cleanup for HiZ
-    char name[10];
+    uint32_t ( *display_send    )(uint32_t); // send max 32 bit
+    uint32_t ( *display_read    )(void);     // read max 32 bit (is thsi actually used?)
+    void     ( *display_macro   )(uint32_t); // macro
+    void     ( *display_setup   )(void);     // setup UI
+    void     ( *display_cleanup )(void);     // cleanup for HiZ
+    char name[10]; // TODO: maybe make this `const char*`???
 } display;
 
 static struct _display displays[2] = {
     // HD44780 is mandatory
-    { HD44780_write,
-      nullfunc3, // read is not used
-      HD44780_macro,
-      HD44780_setup,
-      HD44780_cleanup,
-      "HD44780" },
+    { .display_send    = HD44780_write,
+      .display_read    = nullfunc3, // read is not used
+      .display_macro   = HD44780_macro,
+      .display_setup   = HD44780_setup,
+      .display_cleanup = HD44780_cleanup,
+      .name            = "HD44780",
+    },
 #ifdef DISPLAY_USE_ST7735
-    { ST7735_send,
-      nullfunc3, // read is not used
-      ST7735_macro,
-      ST7735_setup,
-      ST7735_cleanup,
-      "ST7735D/R" },
+    { .display_send    = ST7735_send,
+      .display_read    = nullfunc3, // read is not used
+      .display_macro   = ST7735_macro,
+      .display_setup   = ST7735_setup,
+      .display_cleanup = ST7735_cleanup,
+      .name            = "ST7735D/R",
+    },
 #endif
 };
 

--- a/src/pirate.c
+++ b/src/pirate.c
@@ -579,7 +579,7 @@ static void core0_infinite_loop(void) {
                 uint8_t key_pressed = (uint8_t)ui_term_get_user_input();
                 
                 //all keys deal with screensaver
-                if(key_pressed) { //0x01 is a key press, 0xff is enter
+                if (key_pressed) { //0x01 is a key press, 0xff is enter
                     lcd_screensaver_alarm_reset();
                 }
 
@@ -588,7 +588,7 @@ static void core0_infinite_loop(void) {
                     bp_state = BP_SM_PROCESS_COMMAND;
                     button_irq_disable(0); 
                 }
-
+                
                 enum button_codes press_code = button_check_press(0);
                 if (press_code != BP_BUTT_NO_PRESS) {
                     button_irq_disable(0);

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -2,7 +2,7 @@
 
 #include <ui/ui_cmdln.h>
 
-SYNTAX_STATUS syntax_compile_ex(command_line_history_t* command_history_buffer);
+SYNTAX_STATUS syntax_compile_ex(command_line_history_t * command_history_buffer);
 
 SYNTAX_STATUS syntax_compile(); // defaults to the global command line history buffer (terminal input)
 SYNTAX_STATUS syntax_run(void);

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -1,3 +1,9 @@
-SYNTAX_STATUS syntax_compile(void);
+#pragma once
+
+#include <ui/ui_cmdln.h>
+
+SYNTAX_STATUS syntax_compile_ex(command_line_history_t* command_history_buffer);
+
+SYNTAX_STATUS syntax_compile(); // defaults to the global command line history buffer (terminal input)
 SYNTAX_STATUS syntax_run(void);
 SYNTAX_STATUS syntax_post(void);

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -440,18 +440,17 @@ bool cmdln_args_get_bin(uint32_t* rptr, struct prompt_result* result, uint32_t* 
 
 // parse a decimal value from the first digit
 // notice, we do not pass rptr by reference, so it is not updated
-bool cmdln_args_get_dec(uint32_t* rptr, struct prompt_result* result, uint32_t* value) {
+bool cmdln_args_get_dec_ex(command_info_t * ci, uint32_t* rptr, struct prompt_result* result, uint32_t* value) { // BUGBUG -- deprecate this function
 
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
+    cmdline_validate_invariants(ci);
 
     char c;
     //*result=empty_result;
     result->no_value = true;
     (*value) = 0;
 
-    while (command_info.endptr >= command_info.startptr + (*rptr) &&
-           cmdln_try_peek(command_info.startptr + (*rptr), &c)) // peek at next char
+    while (ci->endptr >= ci->startptr + (*rptr) &&
+           cmdln_try_peek_ex(ci->history, ci->startptr + (*rptr), &c)) // peek at next char
     {
         if ((c < '0') || (c > '9')) // if there is a char, and it is in range
         {
@@ -465,12 +464,15 @@ bool cmdln_args_get_dec(uint32_t* rptr, struct prompt_result* result, uint32_t* 
     }
     return result->success;
 }
+bool cmdln_args_get_dec(uint32_t* rptr, struct prompt_result* result, uint32_t* value) {
+    return cmdln_args_get_dec_ex(&command_info, rptr, result, value);
+}
 
 // decodes value from the cmdline
 // XXXXXX integer
 // 0xXXXX hexadecimal
 // 0bXXXX bin
-bool cmdln_args_get_int(uint32_t* rptr, struct prompt_result* result, uint32_t* value) {
+bool cmdln_args_get_int(uint32_t* rptr, struct prompt_result* result, uint32_t* value) { // BUGBUG -- deprecate this function
 
     cmdline_validate_invariants(&cmdln);
     cmdline_validate_invariants(&command_info);

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -408,19 +408,18 @@ inline bool cmdln_args_get_hex(uint32_t* rptr, prompt_result* result, uint32_t* 
 }
 
 // parse a bin value from the first digit
-// notice, we do not pass rptr by reference, so it is not updated
-bool cmdln_args_get_bin(uint32_t* rptr, struct prompt_result* result, uint32_t* value) {
+bool cmdln_args_get_bin_ex(command_info_t * ci, uint32_t* rptr, struct prompt_result* result, uint32_t* value) {
 
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
+    cmdline_validate_invariants(ci);
 
     char c;
     //*result=empty_result;
     result->no_value = true;
     (*value) = 0;
 
-    while (command_info.endptr >= command_info.startptr + (*rptr) &&
-           cmdln_try_peek(command_info.startptr + (*rptr), &c)) {
+    while (ci->endptr >= ci->startptr + (*rptr) &&
+           cmdln_try_peek_ex(ci->history, ci->startptr + (*rptr), &c)
+        ) {
         if ((c < '0') || (c > '1')) {
             break;
         }
@@ -433,6 +432,11 @@ bool cmdln_args_get_bin(uint32_t* rptr, struct prompt_result* result, uint32_t* 
 
     return result->success;
 }
+bool cmdln_args_get_bin(uint32_t* rptr, struct prompt_result* result, uint32_t* value) { // BUGBUG -- deprecate this function
+    return cmdln_args_get_bin_ex(&command_info, rptr, result, value);
+}
+
+
 
 // parse a decimal value from the first digit
 // notice, we do not pass rptr by reference, so it is not updated

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -19,7 +19,7 @@
 ///        presume that any strings are contiguous, as they may span the
 ///        end / beginning of that circular buffer.
 // TODO: Verify that the offsets are ALWAYS between 0 and UI_CMDBUFFSIZE-1
-struct _command_line cmdln;
+command_line_t cmdln;
 
 /// @brief When supporting multiple commands in a single line, this structure
 ///        provides offsets (relative to cmdln.buf) to the current command,
@@ -32,7 +32,7 @@ struct _command_line cmdln;
 // TODO: change so that cmdln always has current input line starting at
 //       offset 0, and all other history lines are valid / safe to strcpy()
 //       to offset 0.
-struct _command_info_t command_info;
+command_info_t command_info;
 
 static const struct prompt_result empty_result = {0}; // BUGBUG -- this appears to be a useless variable ... all it does is zero-initialize?
 
@@ -64,7 +64,7 @@ static uint32_t cmdln_available_chars(uint32_t rptr, uint32_t wptr) {
     return tmp % UI_CMDBUFFSIZE;
 }
 
-void cmdln_get_command_pointer(struct _command_pointer* cp) {
+void cmdln_get_command_pointer(command_pointer_t* cp) {
     cp->wptr = cmdln.write_offset; // These are offsets, NOT pointers
     cp->rptr = cmdln.read_offset; // These are offsets, NOT pointers
 }
@@ -115,7 +115,7 @@ bool cmdln_try_peek(uint32_t i, char* c) {
     return true;
 }
 
-bool cmdln_try_peek_pointer(struct _command_pointer* cp, uint32_t i, char* c) {
+bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c) {
     uint32_t tmp = cmdln_pu(cp->rptr + i);
     if (tmp == cmdln_pu(cp->wptr)) {
         PRINT_DEBUG("cmdln_try_peek_pointer: Buffer offset 0x%02x (%d) is end of written buffer, no character to peek\n",

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -545,6 +545,7 @@ bool cmdln_args_find_flag_internal(char flag, command_var_t* arg) { // BUGBUG --
 
 
 
+//bool cmdln_args_find_flag_uint32_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t* value);
 // check if a flag is present and get the integer value
 //  returns true if flag is present AND has a string value
 //  use cmdln_args_find_flag to see if a flag was present with no string value
@@ -570,6 +571,7 @@ bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value)
     return true;
 }
 
+//bool cmdln_args_find_flag_string_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t max_len, char* str);
 // check if a flag is present and get the integer value
 //  returns true if flag is present AND has a integer value
 //  use cmdln_args_find_flag to see if a flag was present with no integer value
@@ -594,6 +596,7 @@ bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len
     return true;
 }
 
+//bool cmdln_args_find_flag_ex(command_info_t* cp, char flag);
 // check if a -f(lag) is present. Value is don't care.
 // returns true if flag is present
 bool cmdln_args_find_flag(char flag) {
@@ -608,6 +611,7 @@ bool cmdln_args_find_flag(char flag) {
     return true;
 }
 
+//bool cmdln_args_string_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t max_len, char* str);
 // NOTE: pos is the white-space based token from the current command (not entire command line)
 bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str) {
 
@@ -646,6 +650,7 @@ bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str) {
     return false;
 }
 
+//bool cmdln_args_uint32_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t* value);
 bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value) {
 
     cmdline_validate_invariants(&cmdln);
@@ -677,6 +682,7 @@ bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value) {
     return false;
 }
 
+//bool cmdln_args_float_by_position_ex(command_info_t* cp, uint32_t pos, float* value);
 bool cmdln_args_float_by_position(uint32_t pos, float* value) {
 
     cmdline_validate_invariants(&cmdln);

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -69,16 +69,24 @@ bool cmdline_validate_invariants_command_info(const command_info_t * cmdinfo)
     return true;
 }
 
-void cmdln_init(void) {
+void cmdln_init(command_line_history_t* out_cmdln) {
     PRINT_DEBUG("cmdln_init()\r\n");
-    memset(&cmdln, 0, sizeof(cmdln));
-    memset(&command_info, 0, sizeof(command_info));
+    // currently, this is just setting to all-zero, but this is not necessarily the case in the future
+    memset(out_cmdln, 0, sizeof(command_line_history_t));
     // C11 supports generics!
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
+    cmdline_validate_invariants(out_cmdln);
 }
+void cmdln_init_command_info(command_info_t* out_cmdinfo) {
+    PRINT_DEBUG("cmdln_init_command_info()\r\n");
+    // currently, this is just setting to all-zero, but this is not necessarily the case in the future
+    memset(out_cmdinfo, 0, sizeof(command_info_t));
+    // C11 supports generics!
+    cmdline_validate_invariants(out_cmdinfo);
+}
+
 // buffer offset update, rolls over
 uint32_t cmdln_pu(uint32_t i) {
+    // TODO: Remove this function entirely after `rotate` of the buffer is implemented.
     // Is there any **_other_** reason why UI_CMDBUFFSIZE is commented as "Must be a power of 2?"
     // If not, remove that restriction and simply (optimizer should result in equivalent code):
     return i % UI_CMDBUFFSIZE;
@@ -93,11 +101,11 @@ static uint32_t cmdln_available_chars(uint32_t rptr, uint32_t wptr) {
     return tmp % UI_CMDBUFFSIZE;
 }
 
-void cmdln_get_command_pointer(command_pointer_t* cp) {
-    cmdline_validate_invariants(&cmdln);
-    cp->wptr = cmdln.write_offset; // These are offsets, NOT pointers
-    cp->rptr = cmdln.read_offset; // These are offsets, NOT pointers
-    cmdline_validate_invariants(cp);
+void cmdln_get_command_pointer(command_line_history_t const * command_line_history, command_pointer_t* cp) {
+    cmdline_validate_invariants(command_line_history);
+    cp->wptr = command_line_history->write_offset; // These are offsets, NOT pointers
+    cp->rptr = command_line_history->read_offset; // These are offsets, NOT pointers
+    cmdline_validate_invariants(command_line_history);
 }
 
 bool cmdln_try_add(char* c) {

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -374,15 +374,10 @@ inline bool cmdln_args_get_string(uint32_t rptr, uint32_t max_len, char* string)
     return cmdln_args_get_string_ex(&command_info, rptr, max_len, string);
 }
 
-// TODO: add support for C23-style numeric literal separator '
-//       e.g., 0x0001'3054   0b1101'1011'0111'1111   24'444'444.848'22
-
 // parse a hex value from the first digit
-// notice, we do not pass rptr by reference, so it is not updated
-bool cmdln_args_get_hex(uint32_t* rptr, struct prompt_result* result, uint32_t* value) {
+bool cmdln_args_get_hex_ex(command_info_t * ci, uint32_t * rptr, struct prompt_result* result, uint32_t* value) {
 
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
+    cmdline_validate_invariants(ci);
 
     char c;
 
@@ -390,8 +385,8 @@ bool cmdln_args_get_hex(uint32_t* rptr, struct prompt_result* result, uint32_t* 
     result->no_value = true;
     (*value) = 0;
 
-    while (command_info.endptr >= command_info.startptr + (*rptr) &&
-           cmdln_try_peek(command_info.startptr + (*rptr), &c)) { // peek at next char
+    while (ci->endptr >= ci->startptr + (*rptr) &&
+           cmdln_try_peek_ex(ci->history, ci->startptr + (*rptr), &c)) { // peek at next char
         if (((c >= '0') && (c <= '9'))) {
             (*value) <<= 4;
             (*value) += (c - 0x30);
@@ -407,6 +402,9 @@ bool cmdln_args_get_hex(uint32_t* rptr, struct prompt_result* result, uint32_t* 
         result->no_value = false;
     }
     return result->success;
+}
+inline bool cmdln_args_get_hex(uint32_t* rptr, prompt_result* result, uint32_t* value) { // BUGBUG -- deprecate this function
+    return cmdln_args_get_hex_ex(&command_info, rptr, result, value);
 }
 
 // parse a bin value from the first digit

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -36,7 +36,7 @@ command_info_t command_info;
 
 static const struct prompt_result empty_result = {0}; // BUGBUG -- this appears to be a useless variable ... all it does is zero-initialize?
 
-bool cmdline_validate_invariants_command_line(const command_line_history_t * history)
+bool cmdline_validate_invariants_command_line_history(const command_line_history_t * history)
 {
     BP_ASSERT(history != NULL);
     BP_ASSERT(history->write_offset < UI_CMDBUFFSIZE);
@@ -50,6 +50,8 @@ bool cmdline_validate_invariants_command_pointer(const command_pointer_t * cp)
     BP_ASSERT(cp != NULL);
     BP_ASSERT(cp->wptr < UI_CMDBUFFSIZE);
     BP_ASSERT(cp->rptr < UI_CMDBUFFSIZE);
+    BP_ASSERT(cp->history != NULL);
+    cmdline_validate_invariants_command_line_history(cp->history);
     return true;
 }
 bool cmdline_validate_invariants_command_info(const command_info_t * cmdinfo)
@@ -66,6 +68,8 @@ bool cmdline_validate_invariants_command_info(const command_info_t * cmdinfo)
         (cmdinfo->delimiter == '&') ||
         (cmdinfo->delimiter ==  0 )
     );
+    BP_ASSERT(cmdinfo->history != NULL);
+    cmdline_validate_invariants_command_line_history(cmdinfo->history);
     return true;
 }
 
@@ -76,10 +80,11 @@ void cmdln_init(command_line_history_t* out_cmdln) {
     // C11 supports generics!
     cmdline_validate_invariants(out_cmdln);
 }
-void cmdln_init_command_info(command_info_t* out_cmdinfo) {
+void cmdln_init_command_info(command_line_history_t* command_line_history, command_info_t* out_cmdinfo) {
     PRINT_DEBUG("cmdln_init_command_info()\r\n");
     // currently, this is just setting to all-zero, but this is not necessarily the case in the future
     memset(out_cmdinfo, 0, sizeof(command_info_t));
+    out_cmdinfo->history = command_line_history; // Set the history pointer to the command line history
     // C11 supports generics!
     cmdline_validate_invariants(out_cmdinfo);
 }

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -516,8 +516,8 @@ bool cmdln_args_find_flag_internal_ex(command_info_t * ci, char flag, command_va
     arg->error = false;
     arg->has_arg = false;
     while (ci->endptr >= (ci->startptr + rptr + 1)
-        && cmdln_try_peek(rptr, &dash_c)
-        && cmdln_try_peek(rptr + 1, &flag_c)
+        && cmdln_try_peek_ex(ci->history, rptr, &dash_c)
+        && cmdln_try_peek_ex(ci->history, rptr + 1, &flag_c)
     ) {
         if (dash_c == '-' && flag_c == flag) {
             arg->has_arg = true;
@@ -539,7 +539,7 @@ bool cmdln_args_find_flag_internal_ex(command_info_t * ci, char flag, command_va
     PRINT_NEVER("cmdln_args_find_flag_internal: Flag %c not found\r\n", flag);
     return false;
 }
-bool cmdln_args_find_flag_internal(char flag, command_var_t* arg) {
+bool cmdln_args_find_flag_internal(char flag, command_var_t* arg) { // BUGBUG -- deprecate this function
     return cmdln_args_find_flag_internal_ex(&command_info, flag, arg);
 }
 

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -560,16 +560,15 @@ bool cmdln_args_find_flag(char flag) { // BUGBUG -- deprecate this function
     return cmdln_args_find_flag_ex(&command_info, flag);
 }
 
-//bool cmdln_args_find_flag_uint32_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t* value);
+
 // check if a flag is present and get the integer value
 //  returns true if flag is present AND has a string value
 //  use cmdln_args_find_flag to see if a flag was present with no string value
-bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value) {
+bool cmdln_args_find_flag_uint32_ex(command_info_t* ci, char flag, command_var_t* arg, uint32_t* value) {
 
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
+    cmdline_validate_invariants(ci);
 
-    if (!cmdln_args_find_flag_internal(flag, arg)) {
+    if (!cmdln_args_find_flag_internal_ex(ci, flag, arg)) {
         return false;
     }
 
@@ -578,12 +577,15 @@ bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value)
     }
 
     struct prompt_result result;
-    if (!cmdln_args_get_int(&arg->value_pos, &result, value)) {
+    if (!cmdln_args_get_int_ex(ci, &arg->value_pos, &result, value)) {
         arg->error = true;
         return false;
     }
 
     return true;
+}
+bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value) { // BUGBUG -- deprecate this function
+    return cmdln_args_find_flag_uint32_ex(&command_info, flag, arg, value);
 }
 
 //bool cmdln_args_find_flag_string_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t max_len, char* str);

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -44,7 +44,7 @@ void cmdln_init(void) {
     }
     cmdln.write_offset = 0;
     cmdln.read_offset = 0;
-    cmdln.histptr = 0;
+    cmdln.which_history = 0;
     cmdln.cursor_offset = 0;
 }
 // buffer offset update, rolls over
@@ -171,7 +171,7 @@ bool cmdln_try_discard(uint32_t i) {
 bool cmdln_next_buf_pos(void) {
     cmdln.read_offset = cmdln.write_offset;
     cmdln.cursor_offset = cmdln.write_offset;
-    cmdln.histptr = 0;
+    cmdln.which_history = 0;
 }
 
 // These are new functions to ease argument and options parsing

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -187,9 +187,9 @@ bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c) {
     return true;
 }
 
-bool cmdln_try_discard(uint32_t i) {
+bool cmdln_try_discard_ex(command_line_history_t * history, uint32_t i) {
 
-    cmdline_validate_invariants(&cmdln);
+    cmdline_validate_invariants(history);
 
     // BUGBUG -- this will increment the read offset, even if the read offset
     //           says there's nothing to discard (i.e., rptr == wptr)
@@ -210,18 +210,18 @@ bool cmdln_try_discard(uint32_t i) {
         if (!result) {
             PRINT_WARNING("cmdln_try_discard: requested to discard %d characters, only %d discarded (no more remain)", i, to_discard);
         } else if (to_discard == 1) {
-            char c = cmdln.buf[cmdln.read_offset];
+            char c = history->buf[history->read_offset];
             PRINT_DEBUG("cmdln_try_discard: discarding single character %c (0x%02x) characters", c, c);
         } else {
             PRINT_DEBUG(
                 "cmdln_try_discard: discarding %d characters by adjusting cmdln.rptr from %d to %d",
-                to_discard, cmdln.read_offset, cmdln_pu(cmdln.read_offset + to_discard)
+                to_discard, history->read_offset, cmdln_pu(history->read_offset + to_discard)
             );
         }
-        cmdln.read_offset = cmdln_pu(cmdln.read_offset + to_discard);
+        history->read_offset = cmdln_pu(history->read_offset + to_discard);
     }
 
-    cmdline_validate_invariants(&cmdln);
+    cmdline_validate_invariants(history);
     return result;
 }
 

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -240,11 +240,14 @@ bool cmdln_next_buf_pos_ex(command_line_history_t * history) {
 
 // consume white space (0x20, space)
 //  non_white_space = true, consume non-white space characters (not space)
+// modifies the rptr parameter to be the offset of next non-matching character
+// returns false if ci->endptr is reached.
 static bool cmdln_consume_white_space_ex_impl(command_info_t const * ci, uint32_t* rptr, bool non_white_space) {
 
     cmdline_validate_invariants(ci);
+
     // consume white space
-    while (true) {
+    do {
         char c;
         // all remaining characters matched ... no more characters remain
         if (!(
@@ -262,7 +265,7 @@ static bool cmdln_consume_white_space_ex_impl(command_info_t const * ci, uint32_
         }
         // consume this character and move to next
         (*rptr)++;
-    }
+    } while (true);
 }
 bool cmdln_consume_white_space_ex(command_info_t const * ci, uint32_t* rptr) {
     return cmdln_consume_white_space_ex_impl(ci, rptr, false);
@@ -270,10 +273,10 @@ bool cmdln_consume_white_space_ex(command_info_t const * ci, uint32_t* rptr) {
 bool cmdln_consume_non_white_space_ex(command_info_t const * ci, uint32_t* rptr) {
     return cmdln_consume_white_space_ex_impl(ci, rptr, true);
 }
-inline bool cmdln_consume_white_space(uint32_t* rptr) {
+inline bool cmdln_consume_white_space(uint32_t* rptr) { // TODO: Deprecate this function
     return cmdln_consume_white_space_ex(&command_info, rptr);
 }
-inline bool cmdln_consume_non_white_space(uint32_t* rptr) {
+inline bool cmdln_consume_non_white_space(uint32_t* rptr) { // TODO: Deprecate this function
     return cmdln_consume_non_white_space_ex(&command_info, rptr);
 }
 
@@ -336,6 +339,11 @@ static bool cmdln_args_get_string_new_ex(command_info_t const * ci, uint32_t rea
     }
 }
 
+// This function gets the string at ci->history->buf[rptr], copying it into user-supplied buffer,
+// and ensuring the string is null-terminated.
+// Returns false if no string found.
+// Returns false if max_len was too small for the entire string + terminating null character
+// Else returns true because string was found and fully copied.
 bool cmdln_args_get_string_ex(command_info_t const * ci, uint32_t rptr, uint32_t max_len, char* string) {
 
     char * string_old = string;

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -564,6 +564,8 @@ bool cmdln_find_next_command(struct _command_info_t* cp) {
                 while (cmdln_try_peek(cp->endptr, &d)) {
                     cp->endptr++;
                 }
+                cp->delimiter = 0; // no continuation by another command for this line
+                cp->nextptr = cp->endptr;
                 goto cmdln_find_next_command_success;
             } else {
                 // any character other than space or `#` means this is not a comment
@@ -612,8 +614,8 @@ cmdln_find_next_command_success:
     //       buffer in cmdln_try_peek(), cmdln_try_peek_pointer(), etc.
     //       using `cmdln_pu(uint32_t offset)`
     PRINT_DEBUG(
-        "cmdln_find_next_command: offset %d .. %d (%d chars)\n",
-        cp->startptr, cp->endptr, cp->endptr - cp->startptr
+        "cmdln_find_next_command: offset %d .. %d (%d chars), cmd `%s`\n",
+        cp->startptr, cp->endptr, cp->endptr - cp->startptr, cp->command
         );
 
     cp->endptr--;

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -544,19 +544,20 @@ bool cmdln_args_find_flag_internal(char flag, command_var_t* arg) { // BUGBUG --
 }
 
 
-//bool cmdln_args_find_flag_ex(command_info_t* cp, char flag);
 // check if a -f(lag) is present. Value is don't care.
 // returns true if flag is present
-bool cmdln_args_find_flag(char flag) {
+bool cmdln_args_find_flag_ex(command_info_t* ci, char flag) {
 
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
+    cmdline_validate_invariants(ci);
 
     command_var_t arg;
-    if (!cmdln_args_find_flag_internal(flag, &arg)) {
+    if (!cmdln_args_find_flag_internal_ex(ci, flag, &arg)) {
         return false;
     }
     return true;
+}
+bool cmdln_args_find_flag(char flag) { // BUGBUG -- deprecate this function
+    return cmdln_args_find_flag_ex(&command_info, flag);
 }
 
 //bool cmdln_args_find_flag_uint32_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t* value);

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -115,16 +115,16 @@ static uint32_t cmdln_available_chars(uint32_t rptr, uint32_t wptr) {
     return tmp % UI_CMDBUFFSIZE;
 }
 
-bool cmdln_try_add(char* c) {
-    cmdline_validate_invariants(&cmdln);
+bool cmdln_try_add_ex(command_line_history_t * history, char* c) {
+    cmdline_validate_invariants(history);
     // TODO: leave one space for 0x00 command seperator????
-    if (cmdln_pu(cmdln.write_offset + 1) == cmdln_pu(cmdln.read_offset)) {
+    if (cmdln_pu(history->write_offset + 1) == cmdln_pu(history->read_offset)) {
         PRINT_WARNING("cmdln_try_add: Buffer full, could not add '%c'", *c);
         return false;
     }
-    cmdln.buf[cmdln.write_offset] = (*c);
-    cmdln.write_offset = cmdln_pu(cmdln.write_offset + 1);
-    cmdline_validate_invariants(&cmdln);
+    history->buf[history->write_offset] = (*c);
+    history->write_offset = cmdln_pu(history->write_offset + 1);
+    cmdline_validate_invariants(history);
     return true;
 }
 

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -440,7 +440,7 @@ bool cmdln_args_get_bin(uint32_t* rptr, struct prompt_result* result, uint32_t* 
 
 // parse a decimal value from the first digit
 // notice, we do not pass rptr by reference, so it is not updated
-bool cmdln_args_get_dec_ex(command_info_t * ci, uint32_t* rptr, struct prompt_result* result, uint32_t* value) { // BUGBUG -- deprecate this function
+bool cmdln_args_get_dec_ex(command_info_t * ci, uint32_t* rptr, struct prompt_result* result, uint32_t* value) {
 
     cmdline_validate_invariants(ci);
 
@@ -464,25 +464,25 @@ bool cmdln_args_get_dec_ex(command_info_t * ci, uint32_t* rptr, struct prompt_re
     }
     return result->success;
 }
-bool cmdln_args_get_dec(uint32_t* rptr, struct prompt_result* result, uint32_t* value) {
+bool cmdln_args_get_dec(uint32_t* rptr, struct prompt_result* result, uint32_t* value) { // BUGBUG -- deprecate this function
     return cmdln_args_get_dec_ex(&command_info, rptr, result, value);
 }
+
 
 // decodes value from the cmdline
 // XXXXXX integer
 // 0xXXXX hexadecimal
 // 0bXXXX bin
-bool cmdln_args_get_int(uint32_t* rptr, struct prompt_result* result, uint32_t* value) { // BUGBUG -- deprecate this function
+bool cmdln_args_get_int_ex(command_info_t * ci, uint32_t* rptr, struct prompt_result* result, uint32_t* value) {
 
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
+    cmdline_validate_invariants(ci);
 
     bool r1, r2;
     char p1, p2;
 
     *result = empty_result;
-    r1 = cmdln_try_peek(command_info.startptr + (*rptr), &p1);
-    r2 = cmdln_try_peek(command_info.startptr + (*rptr) + 1, &p2);
+    r1 = cmdln_try_peek_ex(ci->history, ci->startptr + (*rptr), &p1);
+    r2 = cmdln_try_peek_ex(ci->history, ci->startptr + (*rptr) + 1, &p2);
     if (!r1 || (p1 == 0x00)) { // no data, end of data, or no value entered on prompt
         result->no_value = true;
         return false;
@@ -490,17 +490,20 @@ bool cmdln_args_get_int(uint32_t* rptr, struct prompt_result* result, uint32_t* 
 
     if (r2 && (p2 | 0x20) == 'x') { // HEX
         (*rptr) += 2;
-        cmdln_args_get_hex(rptr, result, value);
+        cmdln_args_get_hex_ex(ci, rptr, result, value);
         result->number_format = df_hex;    // whatever from ui_const
     } else if (r2 && (p2 | 0x20) == 'b') { // BIN
         (*rptr) += 2;
-        cmdln_args_get_bin(rptr, result, value);
+        cmdln_args_get_bin_ex(ci, rptr, result, value);
         result->number_format = df_bin; // whatever from ui_const
     } else {                            // DEC
-        cmdln_args_get_dec(rptr, result, value);
+        cmdln_args_get_dec_ex(ci, rptr, result, value);
         result->number_format = df_dec; // whatever from ui_const
     }
     return result->success;
+}
+bool cmdln_args_get_int(uint32_t* rptr, struct prompt_result* result, uint32_t* value) { // BUGBUG -- deprecate this function
+    return cmdln_args_get_int_ex(&command_info, rptr, result, value);
 }
 
 bool cmdln_args_find_flag_internal_ex(command_info_t * ci, char flag, command_var_t* arg) {

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -707,12 +707,11 @@ bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value) { // BUGBUG --
     return cmdln_args_uint32_by_position_ex(&command_info, pos, value);
 }
 
-//bool cmdln_args_string_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t max_len, char* str);
-// NOTE: pos is the white-space based token from the current command (not entire command line)
-bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str) {
 
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
+// NOTE: pos is the white-space based token from the current command (not entire command line)
+bool cmdln_args_string_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t max_len, char* str) {
+
+    cmdline_validate_invariants(ci);
 
     char c;
     uint32_t rptr = 0;
@@ -721,22 +720,22 @@ bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str) {
     // start at beginning of command range
     for (uint32_t i = 0; i < pos + 1; i++) {
         // consume white space
-        if (!cmdln_consume_white_space(&rptr)) {
+        if (!cmdln_consume_white_space_ex(ci, &rptr)) {
             return false;
         }
         // consume non-white space
         if (i != pos) {
-            if (!cmdln_consume_non_white_space(&rptr)) { // consume non-white space
+            if (!cmdln_consume_non_white_space_ex(ci, &rptr)) { // consume non-white space
                 return false;
             }
         } else {
-            cmdln_try_peek(command_info.startptr + (rptr), &c);
+            cmdln_try_peek_ex(ci->history, ci->startptr + (rptr), &c);
             //see if this is a argument or a flag, reject flags
             if (c=='-') {
                 return false;
             }
             struct prompt_result result;
-            if (cmdln_args_get_string(rptr, max_len, str)) {
+            if (cmdln_args_get_string_ex(ci, rptr, max_len, str)) {
                 return true;
             } else {
                 return false;
@@ -745,7 +744,9 @@ bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str) {
     }
     return false;
 }
-
+bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str) { // BUGBUG -- deprecate this function
+    return cmdln_args_string_by_position_ex(&command_info, pos, max_len, str);
+}
 
 // finds the next command in current line of user input
 // could be the comment indicator `#` ... in which case entire string ending in 0x00 is considered the comment

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -45,7 +45,7 @@ void cmdln_init(void) {
     cmdln.write_offset = 0;
     cmdln.read_offset = 0;
     cmdln.histptr = 0;
-    cmdln.cursptr = 0;
+    cmdln.cursor_offset = 0;
 }
 // buffer offset update, rolls over
 uint32_t cmdln_pu(uint32_t i) {
@@ -170,7 +170,7 @@ bool cmdln_try_discard(uint32_t i) {
 
 bool cmdln_next_buf_pos(void) {
     cmdln.read_offset = cmdln.write_offset;
-    cmdln.cursptr = cmdln.write_offset;
+    cmdln.cursor_offset = cmdln.write_offset;
     cmdln.histptr = 0;
 }
 

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -128,23 +128,23 @@ bool cmdln_try_add_ex(command_line_history_t * history, char* c) {
     return true;
 }
 
-bool cmdln_try_remove(char* c) {
-    cmdline_validate_invariants(&cmdln);
-    uint32_t tmp_read_offset = cmdln_pu(cmdln.read_offset);
-    uint32_t tmp_write_offset = cmdln_pu(cmdln.write_offset);
-    if (cmdln_pu(cmdln.read_offset) == cmdln_pu(cmdln.write_offset)) {
+bool cmdln_try_remove_ex(command_line_history_t * history, char* c) {
+    cmdline_validate_invariants(history);
+    uint32_t tmp_read_offset = cmdln_pu(history->read_offset);
+    uint32_t tmp_write_offset = cmdln_pu(history->write_offset);
+    if (cmdln_pu(history->read_offset) == cmdln_pu(history->write_offset)) {
         // this is not a warning, as it's a normal occurrence
         PRINT_DEBUG("cmdln_try_remove: Buffer empty, could not remove character");
         return false;
     }
-    if (cmdln.buf[tmp_read_offset] == 0x00) {
+    if (history->buf[tmp_read_offset] == 0x00) {
         PRINT_DEBUG("cmdln_try_remove: Buffer offset 0x%02x (%d) stored null char, nothing to remove\n",
-                    cmdln.read_offset, cmdln.read_offset);
+                    history->read_offset, history->read_offset);
         return false;
     }
-    (*c) = cmdln.buf[tmp_read_offset];
-    cmdln.read_offset = cmdln_pu(tmp_read_offset + 1);
-    cmdline_validate_invariants(&cmdln);
+    (*c) = history->buf[tmp_read_offset];
+    history->read_offset = cmdln_pu(tmp_read_offset + 1);
+    cmdline_validate_invariants(history);
     return true;
 }
 

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -109,6 +109,11 @@ uint32_t cmdln_pu(uint32_t i) {
     // If not, remove that restriction and simply (optimizer should result in equivalent code):
     return i % UI_CMDBUFFSIZE;
 }
+// Note: although this function is currently agnostic about which history buffer is in use, 
+//       this is only because all history buffers are currently required to be the exact same
+//       size ... which may change in the future.   Consider making this take in the underlying
+//       structure to get the total size, and to validate rptr and wptr are in range....
+// TODO: Change parameter names to reflect they are buffer offsets, not pointers!
 static uint32_t cmdln_available_chars(uint32_t rptr, uint32_t wptr) {
     // This is a circular buffer.
     static_assert( (2*UI_CMDBUFFSIZE) < UINT32_MAX, "UI_CMDBUFFSIZE too large for this shortcut" );
@@ -561,9 +566,6 @@ bool cmdln_args_find_flag_ex(command_info_t* ci, char flag) {
     }
     return true;
 }
-bool cmdln_args_find_flag(char flag) { // BUGBUG -- deprecate this function
-    return cmdln_args_find_flag_ex(&g_legacy_command_info, flag);
-}
 
 
 // check if a flag is present and get the integer value
@@ -589,9 +591,7 @@ bool cmdln_args_find_flag_uint32_ex(command_info_t* ci, char flag, command_var_t
 
     return true;
 }
-bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value) { // BUGBUG -- deprecate this function
-    return cmdln_args_find_flag_uint32_ex(&g_legacy_command_info, flag, arg, value);
-}
+
 
 
 // check if a flag is present and get the integer value
@@ -616,9 +616,6 @@ bool cmdln_args_find_flag_string_ex(command_info_t* ci, char flag, command_var_t
 
     return true;
 }
-bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str) { // BUGBUG -- deprecate this function
-    return cmdln_args_find_flag_string_ex(&g_legacy_command_info, flag, arg, max_len, str);
-}   
 
 bool cmdln_args_float_by_position_ex(command_info_t* ci, uint32_t pos, float* value) {
 
@@ -675,9 +672,6 @@ bool cmdln_args_float_by_position_ex(command_info_t* ci, uint32_t pos, float* va
     }
     return false;
 }
-bool cmdln_args_float_by_position(uint32_t pos, float* value) { // BUGBUG -- deprecate this function
-    return cmdln_args_float_by_position_ex(&g_legacy_command_info, pos, value);
-}
 
 bool cmdln_args_uint32_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t* value) {
 
@@ -707,9 +701,6 @@ bool cmdln_args_uint32_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t
         }
     }
     return false;
-}
-bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value) { // BUGBUG -- deprecate this function
-    return cmdln_args_uint32_by_position_ex(&g_legacy_command_info, pos, value);
 }
 
 
@@ -749,9 +740,7 @@ bool cmdln_args_string_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t
     }
     return false;
 }
-bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str) { // BUGBUG -- deprecate this function
-    return cmdln_args_string_by_position_ex(&g_legacy_command_info, pos, max_len, str);
-}
+
 
 // finds the next command in current line of user input
 // could be the comment indicator `#` ... in which case entire string ending in 0x00 is considered the comment

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -674,11 +674,9 @@ bool cmdln_args_float_by_position(uint32_t pos, float* value) { // BUGBUG -- dep
     return cmdln_args_float_by_position_ex(&command_info, pos, value);
 }
 
-//bool cmdln_args_uint32_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t* value);
-bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value) {
+bool cmdln_args_uint32_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t* value) {
 
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
+    cmdline_validate_invariants(ci);
 
     char c;
     uint32_t rptr = 0;
@@ -686,17 +684,17 @@ bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value) {
     PRINT_NEVER("cmdln_args_uint32_by_position(%d)\r\n", pos);
     for (uint32_t i = 0; i < pos + 1; i++) {
         // consume white space
-        if (!cmdln_consume_white_space(&rptr)) {
+        if (!cmdln_consume_white_space_ex(ci, &rptr)) {
             return false;
         }
         // consume non-white space
         if (i != pos) {
-            if (!cmdln_consume_non_white_space(&rptr)) { // consume non-white space
+            if (!cmdln_consume_non_white_space_ex(ci, &rptr)) { // consume non-white space
                 return false;
             }
         } else {
             struct prompt_result result;
-            if (cmdln_args_get_int(&rptr, &result, value)) {
+            if (cmdln_args_get_int_ex(ci, &rptr, &result, value)) {
                 return true;
             } else {
                 return false;
@@ -704,6 +702,9 @@ bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value) {
         }
     }
     return false;
+}
+bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value) { // BUGBUG -- deprecate this function
+    return cmdln_args_uint32_by_position_ex(&command_info, pos, value);
 }
 
 //bool cmdln_args_string_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t max_len, char* str);

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -588,16 +588,15 @@ bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value)
     return cmdln_args_find_flag_uint32_ex(&command_info, flag, arg, value);
 }
 
-//bool cmdln_args_find_flag_string_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t max_len, char* str);
+
 // check if a flag is present and get the integer value
 //  returns true if flag is present AND has a integer value
 //  use cmdln_args_find_flag to see if a flag was present with no integer value
-bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str) {
+bool cmdln_args_find_flag_string_ex(command_info_t* ci, char flag, command_var_t* arg, uint32_t max_len, char* str) {
 
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
+    cmdline_validate_invariants(ci);
 
-    if (!cmdln_args_find_flag_internal(flag, arg)) {
+    if (!cmdln_args_find_flag_internal_ex(ci, flag, arg)) {
         return false;
     }
 
@@ -605,14 +604,16 @@ bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len
         return false;
     }
 
-    if (!cmdln_args_get_string(arg->value_pos, max_len, str)) {
+    if (!cmdln_args_get_string_ex(ci, arg->value_pos, max_len, str)) {
         arg->error = true;
         return false;
     }
 
     return true;
 }
-
+bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str) { // BUGBUG -- deprecate this function
+    return cmdln_args_find_flag_string_ex(&command_info, flag, arg, max_len, str);
+}   
 
 //bool cmdln_args_float_by_position_ex(command_info_t* cp, uint32_t pos, float* value);
 bool cmdln_args_float_by_position(uint32_t pos, float* value) {

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -544,6 +544,20 @@ bool cmdln_args_find_flag_internal(char flag, command_var_t* arg) { // BUGBUG --
 }
 
 
+//bool cmdln_args_find_flag_ex(command_info_t* cp, char flag);
+// check if a -f(lag) is present. Value is don't care.
+// returns true if flag is present
+bool cmdln_args_find_flag(char flag) {
+
+    cmdline_validate_invariants(&cmdln);
+    cmdline_validate_invariants(&command_info);
+
+    command_var_t arg;
+    if (!cmdln_args_find_flag_internal(flag, &arg)) {
+        return false;
+    }
+    return true;
+}
 
 //bool cmdln_args_find_flag_uint32_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t* value);
 // check if a flag is present and get the integer value
@@ -596,91 +610,6 @@ bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len
     return true;
 }
 
-//bool cmdln_args_find_flag_ex(command_info_t* cp, char flag);
-// check if a -f(lag) is present. Value is don't care.
-// returns true if flag is present
-bool cmdln_args_find_flag(char flag) {
-
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
-
-    command_var_t arg;
-    if (!cmdln_args_find_flag_internal(flag, &arg)) {
-        return false;
-    }
-    return true;
-}
-
-//bool cmdln_args_string_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t max_len, char* str);
-// NOTE: pos is the white-space based token from the current command (not entire command line)
-bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str) {
-
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
-
-    char c;
-    uint32_t rptr = 0;
-    PRINT_NEVER("cmdln_args_string_by_position(%d, %d)\r\n", pos, max_len);
-    memset(str, 0x00, max_len);
-    // start at beginning of command range
-    for (uint32_t i = 0; i < pos + 1; i++) {
-        // consume white space
-        if (!cmdln_consume_white_space(&rptr)) {
-            return false;
-        }
-        // consume non-white space
-        if (i != pos) {
-            if (!cmdln_consume_non_white_space(&rptr)) { // consume non-white space
-                return false;
-            }
-        } else {
-            cmdln_try_peek(command_info.startptr + (rptr), &c);
-            //see if this is a argument or a flag, reject flags
-            if (c=='-') {
-                return false;
-            }
-            struct prompt_result result;
-            if (cmdln_args_get_string(rptr, max_len, str)) {
-                return true;
-            } else {
-                return false;
-            }
-        }
-    }
-    return false;
-}
-
-//bool cmdln_args_uint32_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t* value);
-bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value) {
-
-    cmdline_validate_invariants(&cmdln);
-    cmdline_validate_invariants(&command_info);
-
-    char c;
-    uint32_t rptr = 0;
-    // start at beginning of command range
-    PRINT_NEVER("cmdln_args_uint32_by_position(%d)\r\n", pos);
-    for (uint32_t i = 0; i < pos + 1; i++) {
-        // consume white space
-        if (!cmdln_consume_white_space(&rptr)) {
-            return false;
-        }
-        // consume non-white space
-        if (i != pos) {
-            if (!cmdln_consume_non_white_space(&rptr)) { // consume non-white space
-                return false;
-            }
-        } else {
-            struct prompt_result result;
-            if (cmdln_args_get_int(&rptr, &result, value)) {
-                return true;
-            } else {
-                return false;
-            }
-        }
-    }
-    return false;
-}
 
 //bool cmdln_args_float_by_position_ex(command_info_t* cp, uint32_t pos, float* value);
 bool cmdln_args_float_by_position(uint32_t pos, float* value) {
@@ -738,6 +667,78 @@ bool cmdln_args_float_by_position(uint32_t pos, float* value) {
     }
     return false;
 }
+
+//bool cmdln_args_uint32_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t* value);
+bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value) {
+
+    cmdline_validate_invariants(&cmdln);
+    cmdline_validate_invariants(&command_info);
+
+    char c;
+    uint32_t rptr = 0;
+    // start at beginning of command range
+    PRINT_NEVER("cmdln_args_uint32_by_position(%d)\r\n", pos);
+    for (uint32_t i = 0; i < pos + 1; i++) {
+        // consume white space
+        if (!cmdln_consume_white_space(&rptr)) {
+            return false;
+        }
+        // consume non-white space
+        if (i != pos) {
+            if (!cmdln_consume_non_white_space(&rptr)) { // consume non-white space
+                return false;
+            }
+        } else {
+            struct prompt_result result;
+            if (cmdln_args_get_int(&rptr, &result, value)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+    return false;
+}
+
+//bool cmdln_args_string_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t max_len, char* str);
+// NOTE: pos is the white-space based token from the current command (not entire command line)
+bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str) {
+
+    cmdline_validate_invariants(&cmdln);
+    cmdline_validate_invariants(&command_info);
+
+    char c;
+    uint32_t rptr = 0;
+    PRINT_NEVER("cmdln_args_string_by_position(%d, %d)\r\n", pos, max_len);
+    memset(str, 0x00, max_len);
+    // start at beginning of command range
+    for (uint32_t i = 0; i < pos + 1; i++) {
+        // consume white space
+        if (!cmdln_consume_white_space(&rptr)) {
+            return false;
+        }
+        // consume non-white space
+        if (i != pos) {
+            if (!cmdln_consume_non_white_space(&rptr)) { // consume non-white space
+                return false;
+            }
+        } else {
+            cmdln_try_peek(command_info.startptr + (rptr), &c);
+            //see if this is a argument or a flag, reject flags
+            if (c=='-') {
+                return false;
+            }
+            struct prompt_result result;
+            if (cmdln_args_get_string(rptr, max_len, str)) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+    return false;
+}
+
 
 // finds the next command in current line of user input
 // could be the comment indicator `#` ... in which case entire string ending in 0x00 is considered the comment

--- a/src/ui/ui_cmdln.c
+++ b/src/ui/ui_cmdln.c
@@ -148,16 +148,16 @@ bool cmdln_try_remove(char* c) {
     return true;
 }
 
-bool cmdln_try_peek(uint32_t i, char* c) {
-    cmdline_validate_invariants(&cmdln);
-    uint32_t tmp = cmdln_pu(cmdln.read_offset + i);
-    if (tmp == cmdln_pu(cmdln.write_offset)) {
+bool cmdln_try_peek_ex(command_line_history_t const * history, uint32_t i, char* c) {
+    cmdline_validate_invariants(history);
+    uint32_t tmp = cmdln_pu(history->read_offset + i);
+    if (tmp == cmdln_pu(history->write_offset)) {
         PRINT_NEVER("cmdln_try_peek: Buffer offset 0x%02x (%d) is end of written buffer, no character to peek\n",
                     tmp, tmp);
         return false;
     }
 
-    (*c) = cmdln.buf[tmp];
+    (*c) = history->buf[tmp];
     if ((*c) == 0x00) {
         PRINT_NEVER("cmdln_try_peek: Buffer offset 0x%02x (%d) stored null char\n", tmp, tmp);
         return false;

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -12,6 +12,7 @@ typedef struct _command_line_history_t {
     uint32_t cursor_offset;   // Offset into command_line_history_t.buf where the cursor is currently positioned
     char buf[UI_CMDBUFFSIZE]; // Global circular buffer used to store command line input and history
 } command_line_history_t;
+extern command_line_history_t cmdln;
 
 // This structure is used to track a single "command" and all options associated with that command.
 // At present, multiple commands can be entered in a single command line,
@@ -70,11 +71,13 @@ bool cmdline_validate_invariants_command_info(const command_info_t * cmdinfo);
 
 
 typedef struct command_var_struct {
-    bool has_arg;
-    bool has_value;
+    // clang-format off
+    bool     has_arg;
+    bool     has_value;
     uint32_t value_pos;
-    bool error;
-    uint8_t number_format;
+    bool     error;
+    uint8_t  number_format;
+    // clang-format on
 } command_var_t;
 
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -89,15 +92,24 @@ bool cmdln_args_string_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t
 
 bool cmdln_try_add_ex(command_line_history_t * command_line_history, char* c);
 bool cmdln_try_remove_ex(command_line_history_t * command_line_history, char* c);
+
+// try to peek 0+n bytes (no offsets updated)
+// returns false if at the end of the buffer
+// this should always be used sequentially from zero,
+// if wanting to peek multiple characters forward
+//     e.g., bool got_char = peek(0, &c) && peek(1, &c);
+// to avoid missing the end of the buffer
 bool cmdln_try_peek_ex(command_line_history_t const * command_line_history, uint32_t i, char* c);
 bool cmdln_try_discard_ex(command_line_history_t* command_history_buffer, uint32_t i);
 bool cmdln_next_buf_pos_ex(command_line_history_t* command_history_buffer);
 
-// this one is already OK, once we track the .history field
-// bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
+// peek at offset from a specific command_pointer_t
+bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
 
 bool cmdln_info_ex(command_line_history_t* command_history_buffer);
 bool cmdln_info_uint32_ex(command_line_history_t* command_history_buffer);
+
+
 
 
 
@@ -127,13 +139,7 @@ uint32_t cmdln_pu(uint32_t i);
 bool cmdln_try_add(char* c);
 // try to get a byte, return false if buffer empty
 bool cmdln_try_remove(char* c);
-// try to peek 0+n bytes (no offsets updated)
-// returns false if at the end of the buffer
-// this should always be used sequentially from zero,
-// if wanting to peek multiple characters forward
-//     e.g., bool got_char = peek(0, &c) && peek(1, &c);
-// to avoid missing the end of the buffer
-bool cmdln_try_peek(uint32_t i, char* c);
+inline bool cmdln_try_peek(uint32_t i, char* c) { return cmdln_try_peek_ex(&cmdln, i, c);}
 // try to discard n bytes (advance the read offset)
 // return false if end of buffer is reached
 // (should be used with try_peek to confirm before discarding...)
@@ -144,6 +150,4 @@ bool cmdln_try_discard(uint32_t i);
 bool cmdln_next_buf_pos(); // TODO: Rename this API to more clearly indicate its purpose
 
 
-bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
 
-extern command_line_history_t cmdln;

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -8,7 +8,7 @@
 struct _command_line {
     uint32_t write_offset;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t read_offset;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
-    uint32_t histptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
+    uint32_t which_history;        // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t cursor_offset; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     char buf[UI_CMDBUFFSIZE];
 };

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -99,6 +99,7 @@ bool cmdln_next_buf_pos_ex(command_line_history_t* command_history_buffer); // T
 bool cmdln_info_ex(command_line_history_t* command_history_buffer);
 
 bool cmdln_args_find_flag_ex(command_info_t* cp, char flag);
+bool cmdln_args_find_flag_uint32_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t* value);
 
 
 
@@ -128,11 +129,11 @@ inline bool cmdln_try_discard(uint32_t i) { return cmdln_try_discard_ex(&cmdln, 
 inline bool cmdln_next_buf_pos() { return cmdln_next_buf_pos_ex(&cmdln); } 
 
 bool cmdln_args_find_flag(char flag);
+bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value);
 
 #pragma endregion // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
 
 
-bool cmdln_args_find_flag_uint32_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t* value);
 bool cmdln_args_find_flag_string_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t max_len, char* str);
 bool cmdln_args_float_by_position_ex(command_info_t* cp, uint32_t pos, float* value);
 bool cmdln_args_uint32_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t* value);
@@ -141,7 +142,6 @@ bool cmdln_args_string_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t
 ////////////////////////////////////////////////////////////////////////////////////////
 // TODO: update these to be inline functions for the ...ex() versions
 ////////////////////////////////////////////////////////////////////////////////////////
-bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value);
 bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str);
 bool cmdln_args_float_by_position(uint32_t pos, float* value);
 bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value);

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -49,7 +49,7 @@ typedef struct _command_pointer_t {
 
 
 
-void cmdln_init(command_line_history_t* out_cmdln);
+void cmdln_init_command_history(command_line_history_t* out_cmdln);
 void cmdln_init_command_info(command_line_history_t* command_line_history, command_info_t* out_cmdinfo);
 void cmdln_init_command_pointer(command_line_history_t* command_line_history, command_pointer_t* out_cmdinfo);
 

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -133,10 +133,10 @@ uint32_t cmdln_pu(uint32_t i);
 
 
 // try to add a byte to the command line buffer, return false if buffer full
-bool cmdln_try_add(char* c);
+inline bool cmdln_try_add(char* c) { return cmdln_try_add_ex(&cmdln, c); }
 // try to get a byte, return false if buffer empty
 bool cmdln_try_remove(char* c);
-inline bool cmdln_try_peek(uint32_t i, char* c) { return cmdln_try_peek_ex(&cmdln, i, c);}
+inline bool cmdln_try_peek(uint32_t i, char* c) { return cmdln_try_peek_ex(&cmdln, i, c); }
 // try to discard n bytes (advance the read offset)
 // return false if end of buffer is reached
 // (should be used with try_peek to confirm before discarding...)

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -13,15 +13,19 @@ struct _command_line {
     char buf[UI_CMDBUFFSIZE];
 };
 
-// This structure is used to track a single "command" input.
+// This structure is used to track a single "command" and all options associated with that command.
 // At present, multiple commands can be entered in a single command line,
 // and this structure will define the offsets to a single one of those commands.
+
+// TODO: rename this structure to avoid confusion between pointers / offsets ... maybe `_command_extent`?
 struct _command_pointer {
     uint32_t wptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t rptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
 };
 
-// 
+// TODO: document the fields in this structure
+// WARNING: the end offset might EXCEED UI_CMDBUFFSIZE?!  Change to be a character count instead of end offset?
+// WARNING: Some fields are modulo'd by UI_CMDBUFFSIZE, others are NOT.  This is just asking for bugs....
 struct _command_info_t {
     uint32_t rptr;     // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t wptr;     // NOT a pointer .. this is an offset into member .buf (a circular buffer)
@@ -29,7 +33,7 @@ struct _command_info_t {
     uint32_t endptr;   // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t nextptr;  // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     char delimiter;
-    char command[9];   // BUGBUG -- Hard-coded buffer size ...
+    char command[9];   // BUGBUG -- Hard-coded buffer size ... should this be MAX_COMMAND_LENGTH?
 };
 
 typedef struct command_var_struct {

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -98,6 +98,9 @@ bool cmdln_next_buf_pos_ex(command_line_history_t* command_history_buffer); // T
 // Debug function ... dump parsing of current line of input to debugger
 bool cmdln_info_ex(command_line_history_t* command_history_buffer);
 
+bool cmdln_args_find_flag_ex(command_info_t* cp, char flag);
+
+
 
 // Finds the next command (if any) in the current single line of command input
 bool cmdln_find_next_command(command_info_t* cp);
@@ -124,10 +127,11 @@ inline bool cmdln_try_discard(uint32_t i) { return cmdln_try_discard_ex(&cmdln, 
 // this allows the history scroll through the circular buffer
 inline bool cmdln_next_buf_pos() { return cmdln_next_buf_pos_ex(&cmdln); } 
 
+bool cmdln_args_find_flag(char flag);
+
 #pragma endregion // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
 
 
-bool cmdln_args_find_flag_ex(command_info_t* cp, char flag);
 bool cmdln_args_find_flag_uint32_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t* value);
 bool cmdln_args_find_flag_string_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t max_len, char* str);
 bool cmdln_args_float_by_position_ex(command_info_t* cp, uint32_t pos, float* value);
@@ -137,7 +141,6 @@ bool cmdln_args_string_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t
 ////////////////////////////////////////////////////////////////////////////////////////
 // TODO: update these to be inline functions for the ...ex() versions
 ////////////////////////////////////////////////////////////////////////////////////////
-bool cmdln_args_find_flag(char flag);
 bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value);
 bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str);
 bool cmdln_args_float_by_position(uint32_t pos, float* value);

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -5,13 +5,13 @@
 // so it may have multiple command lines stored within.
 // When read and write offsets are equal, the buffer is empty.
 // Read and write offsets should ALWAYS be between 0 and UI_CMDBUFFSIZE-1.
-typedef struct _command_line_t {
-    uint32_t write_offset;   // Offset into command_line_t.buf
-    uint32_t read_offset;    // Offset into command_line_t.buf // This will eventually go away, when current command line is always at zero
-    uint32_t which_history;  // 0: History not used, 1..N: previous command that was copied into current command line
-    uint32_t cursor_offset;  // Offset into command_line_t.buf where the cursor is currently positioned
+typedef struct _command_line_history_t {
+    uint32_t write_offset;    // Offset into command_line_history_t.buf
+    uint32_t read_offset;     // Offset into command_line_history_t.buf // This will eventually go away, when current command line is always at zero
+    uint32_t which_history;   // 0: History not used, 1..N: previous command that was copied into current command line
+    uint32_t cursor_offset;   // Offset into command_line_history_t.buf where the cursor is currently positioned
     char buf[UI_CMDBUFFSIZE]; // Global circular buffer used to store command line input and history
-} command_line_t;
+} command_line_history_t;
 
 // This structure is used to track a single "command" and all options associated with that command.
 // At present, multiple commands can be entered in a single command line,
@@ -36,7 +36,7 @@ typedef struct _command_info_t {
     char command[9];   // BUGBUG -- Hard-coded buffer size ... should this be MAX_COMMAND_LENGTH?
 } command_info_t;
 
-bool cmdline_validate_invariants_command_line(const command_line_t * cmdline);
+bool cmdline_validate_invariants_command_line(const command_line_history_t * cmdline);
 bool cmdline_validate_invariants_command_pointer(const command_pointer_t * cp);
 bool cmdline_validate_invariants_command_info(const command_info_t * cmdinfo);
 
@@ -44,8 +44,8 @@ bool cmdline_validate_invariants_command_info(const command_info_t * cmdinfo);
     _Generic((X),                  \
         command_pointer_t *       : cmdline_validate_invariants_command_pointer(X), \
         const command_pointer_t * : cmdline_validate_invariants_command_pointer(X), \
-        command_line_t *          : cmdline_validate_invariants_command_line(X), \
-        const command_line_t *    : cmdline_validate_invariants_command_line(X), \
+        command_line_history_t *          : cmdline_validate_invariants_command_line(X), \
+        const command_line_history_t *    : cmdline_validate_invariants_command_line(X), \
         command_info_t *          : cmdline_validate_invariants_command_info(X), \
         const command_info_t *    : cmdline_validate_invariants_command_info(X), \
         default                   : static_assert(false, "Unsupported type for cmdline_validate_invariants") \
@@ -100,4 +100,4 @@ bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
 // TODO: rename this API to avoid confusion about pointers / offsets
 void cmdln_get_command_pointer(command_pointer_t* cp);
 
-extern command_line_t cmdln;
+extern command_line_history_t cmdln;

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -103,6 +103,7 @@ bool cmdln_args_find_flag_uint32_ex(command_info_t* ci, char flag, command_var_t
 bool cmdln_args_find_flag_string_ex(command_info_t* ci, char flag, command_var_t* arg, uint32_t max_len, char* str);
 
 bool cmdln_args_float_by_position_ex(command_info_t* ci, uint32_t pos, float* value);
+bool cmdln_args_uint32_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t* value);
 
 
 // Finds the next command (if any) in the current single line of command input
@@ -135,17 +136,16 @@ bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value)
 bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str);
 
 bool cmdln_args_float_by_position(uint32_t pos, float* value);
+bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value);
 
 #pragma endregion // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
 
 
-bool cmdln_args_uint32_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t* value);
 bool cmdln_args_string_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t max_len, char* str);
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // TODO: update these to be inline functions for the ...ex() versions
 ////////////////////////////////////////////////////////////////////////////////////////
-bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value);
 bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str);
 
 

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -98,15 +98,16 @@ bool cmdln_next_buf_pos_ex(command_line_history_t* command_history_buffer); // T
 // Debug function ... dump parsing of current line of input to debugger
 bool cmdln_info_ex(command_line_history_t* command_history_buffer);
 
-bool cmdln_args_find_flag_ex(command_info_t* cp, char flag);
-bool cmdln_args_find_flag_uint32_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t* value);
+bool cmdln_args_find_flag_ex(command_info_t* ci, char flag);
+bool cmdln_args_find_flag_uint32_ex(command_info_t* ci, char flag, command_var_t* arg, uint32_t* value);
+bool cmdln_args_find_flag_string_ex(command_info_t* ci, char flag, command_var_t* arg, uint32_t max_len, char* str);
 
 
 
 // Finds the next command (if any) in the current single line of command input
-bool cmdln_find_next_command(command_info_t* cp);
+bool cmdln_find_next_command(command_info_t* ci);
 // peek at offset from a specific command_pointer_t
-bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
+bool cmdln_try_peek_pointer(command_pointer_t* ci, uint32_t i, char* c);
 
 #pragma endregion // Updated ..._ex() functions to exist and use parameter -- Phase 1
 
@@ -130,19 +131,18 @@ inline bool cmdln_next_buf_pos() { return cmdln_next_buf_pos_ex(&cmdln); }
 
 bool cmdln_args_find_flag(char flag);
 bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value);
+bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str);
 
 #pragma endregion // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
 
 
-bool cmdln_args_find_flag_string_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t max_len, char* str);
-bool cmdln_args_float_by_position_ex(command_info_t* cp, uint32_t pos, float* value);
-bool cmdln_args_uint32_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t* value);
-bool cmdln_args_string_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t max_len, char* str);
+bool cmdln_args_float_by_position_ex(command_info_t* ci, uint32_t pos, float* value);
+bool cmdln_args_uint32_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t* value);
+bool cmdln_args_string_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t max_len, char* str);
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // TODO: update these to be inline functions for the ...ex() versions
 ////////////////////////////////////////////////////////////////////////////////////////
-bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str);
 bool cmdln_args_float_by_position(uint32_t pos, float* value);
 bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value);
 bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str);

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -104,6 +104,7 @@ bool cmdln_args_find_flag_string_ex(command_info_t* ci, char flag, command_var_t
 
 bool cmdln_args_float_by_position_ex(command_info_t* ci, uint32_t pos, float* value);
 bool cmdln_args_uint32_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t* value);
+bool cmdln_args_string_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t max_len, char* str);
 
 
 // Finds the next command (if any) in the current single line of command input
@@ -137,17 +138,9 @@ bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len
 
 bool cmdln_args_float_by_position(uint32_t pos, float* value);
 bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value);
-
-#pragma endregion // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
-
-
-bool cmdln_args_string_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t max_len, char* str);
-
-////////////////////////////////////////////////////////////////////////////////////////
-// TODO: update these to be inline functions for the ...ex() versions
-////////////////////////////////////////////////////////////////////////////////////////
 bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str);
 
+#pragma endregion // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
 
 
 // TODO: Remove this once rotate operation implemented

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -106,8 +106,8 @@ bool cmdln_next_buf_pos_ex(command_line_history_t* command_history_buffer);
 // peek at offset from a specific command_pointer_t
 bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
 
+// Debug function ... dump parsing of current line of input to debugger
 bool cmdln_info_ex(command_line_history_t* command_history_buffer);
-bool cmdln_info_uint32_ex(command_line_history_t* command_history_buffer);
 
 
 
@@ -127,9 +127,6 @@ bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str);
 // Finds the next command (if any) in the current single line of command input
 bool cmdln_find_next_command(command_info_t* cp);
 
-// Debug functions to dump state to debugger
-bool cmdln_info(void);
-bool cmdln_info_uint32(void);
 
 // TODO: Remove this once rotate operation implemented
 uint32_t cmdln_pu(uint32_t i);

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -104,7 +104,6 @@ bool cmdln_find_next_command(command_info_t* cp);
 // peek at offset from a specific command_pointer_t
 bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
 
-
 #pragma endregion // Updated ..._ex() functions to exist and use parameter -- Phase 1
 
 #pragma region    // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
@@ -124,6 +123,7 @@ inline bool cmdln_try_discard(uint32_t i) { return cmdln_try_discard_ex(&cmdln, 
 // allowing the next command line to be entered after the previous.
 // this allows the history scroll through the circular buffer
 inline bool cmdln_next_buf_pos() { return cmdln_next_buf_pos_ex(&cmdln); } 
+
 #pragma endregion // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
 
 
@@ -133,7 +133,6 @@ bool cmdln_args_find_flag_string_ex(command_info_t* cp, char flag, command_var_t
 bool cmdln_args_float_by_position_ex(command_info_t* cp, uint32_t pos, float* value);
 bool cmdln_args_uint32_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t* value);
 bool cmdln_args_string_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t max_len, char* str);
-bool cmdln_find_next_command(command_info_t* cp);
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // TODO: update these to be inline functions for the ...ex() versions

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -1,8 +1,8 @@
 struct _command_line {
-    uint32_t wptr;
-    uint32_t rptr;
-    uint32_t histptr;
-    uint32_t cursptr;
+    uint32_t wptr;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
+    uint32_t rptr;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
+    uint32_t histptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
+    uint32_t cursptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     char buf[UI_CMDBUFFSIZE];
 };
 

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -135,7 +135,7 @@ uint32_t cmdln_pu(uint32_t i);
 // try to add a byte to the command line buffer, return false if buffer full
 inline bool cmdln_try_add(char* c) { return cmdln_try_add_ex(&cmdln, c); }
 // try to get a byte, return false if buffer empty
-bool cmdln_try_remove(char* c);
+inline bool cmdln_try_remove(char* c) { return cmdln_try_remove_ex(&cmdln, c); }
 inline bool cmdln_try_peek(uint32_t i, char* c) { return cmdln_try_peek_ex(&cmdln, i, c); }
 // try to discard n bytes (advance the read offset)
 // return false if end of buffer is reached

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -9,7 +9,7 @@ struct _command_line {
     uint32_t write_offset;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t read_offset;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t histptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
-    uint32_t cursptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
+    uint32_t cursor_offset; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     char buf[UI_CMDBUFFSIZE];
 };
 

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -40,16 +40,16 @@ bool cmdline_validate_invariants_command_line(const command_line_history_t * cmd
 bool cmdline_validate_invariants_command_pointer(const command_pointer_t * cp);
 bool cmdline_validate_invariants_command_info(const command_info_t * cmdinfo);
 
+// Yes, this is syntactic sugar.
 #define cmdline_validate_invariants(X) \
     _Generic((X),                  \
-        command_pointer_t *       : cmdline_validate_invariants_command_pointer(X), \
-        const command_pointer_t * : cmdline_validate_invariants_command_pointer(X), \
-        command_line_history_t *          : cmdline_validate_invariants_command_line(X), \
-        const command_line_history_t *    : cmdline_validate_invariants_command_line(X), \
-        command_info_t *          : cmdline_validate_invariants_command_info(X), \
-        const command_info_t *    : cmdline_validate_invariants_command_info(X), \
-        default                   : static_assert(false, "Unsupported type for cmdline_validate_invariants") \
-        )
+        command_pointer_t *       : cmdline_validate_invariants_command_pointer, \
+        const command_pointer_t * : cmdline_validate_invariants_command_pointer, \
+        command_line_history_t *          : cmdline_validate_invariants_command_line, \
+        const command_line_history_t *    : cmdline_validate_invariants_command_line, \
+        command_info_t *          : cmdline_validate_invariants_command_info, \
+        const command_info_t *    : cmdline_validate_invariants_command_info  \
+        )(X)
 
 
 

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -116,34 +116,59 @@ bool cmdln_try_peek_pointer(command_pointer_t* ci, uint32_t i, char* c);
 
 #pragma region    // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
 
+#if !defined(BP_NO_LEGACY_CMDLINE_FUNCTIONS)
+
 // These should all be inline functions that call the ..._ex() version
+extern command_info_t g_legacy_command_info;
 
 // try to add a byte to the command line buffer, return false if buffer full
-inline bool cmdln_try_add(char* c) { return cmdln_try_add_ex(&cmdln, c); }
+inline bool cmdln_try_add(char* c) {
+    return cmdln_try_add_ex(&cmdln, c);
+}
 // try to get a byte, return false if buffer empty
-inline bool cmdln_try_remove(char* c) { return cmdln_try_remove_ex(&cmdln, c); }
-inline bool cmdln_try_peek(uint32_t i, char* c) { return cmdln_try_peek_ex(&cmdln, i, c); }
+inline bool cmdln_try_remove(char* c) {
+    return cmdln_try_remove_ex(&cmdln, c);
+}
+inline bool cmdln_try_peek(uint32_t i, char* c) {
+    return cmdln_try_peek_ex(&cmdln, i, c);
+}
 // try to discard n bytes (advance the read offset)
 // return false if end of buffer is reached
 // (should be used with try_peek to confirm before discarding...)
-inline bool cmdln_try_discard(uint32_t i) { return cmdln_try_discard_ex(&cmdln, i); }
+inline bool cmdln_try_discard(uint32_t i) {
+    return cmdln_try_discard_ex(&cmdln, i);
+}
 // this moves the read offset to the write offset,
 // allowing the next command line to be entered after the previous.
 // this allows the history scroll through the circular buffer
-inline bool cmdln_next_buf_pos() { return cmdln_next_buf_pos_ex(&cmdln); } 
+inline bool cmdln_next_buf_pos() {
+    return cmdln_next_buf_pos_ex(&cmdln);
+} 
+inline bool cmdln_args_find_flag(char flag) {
+    return cmdln_args_find_flag_ex(&g_legacy_command_info, flag);
+}
 
-bool cmdln_args_find_flag(char flag);
-bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value);
-bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str);
-
-bool cmdln_args_float_by_position(uint32_t pos, float* value);
-bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value);
-bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str);
+inline bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value) { // BUGBUG -- deprecate this function
+    return cmdln_args_find_flag_uint32_ex(&g_legacy_command_info, flag, arg, value);
+}
+inline bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str) { // BUGBUG -- deprecate this function
+    return cmdln_args_find_flag_string_ex(&g_legacy_command_info, flag, arg, max_len, str);
+}
+inline bool cmdln_args_float_by_position(uint32_t pos, float* value) { // BUGBUG -- deprecate this function
+    return cmdln_args_float_by_position_ex(&g_legacy_command_info, pos, value);
+}
+inline bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value) { // BUGBUG -- deprecate this function
+    return cmdln_args_uint32_by_position_ex(&g_legacy_command_info, pos, value);
+}
+inline bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str) { // BUGBUG -- deprecate this function
+    return cmdln_args_string_by_position_ex(&g_legacy_command_info, pos, max_len, str);
+}
+#endif // !defined(BP_NO_LEGACY_CMDLINE_FUNCTIONS)
 
 #pragma endregion // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
 
 
-// TODO: Remove this once rotate operation implemented
+// TODO: Remove this once rotate operation implemented so command line always starts at offset zero
 uint32_t cmdln_pu(uint32_t i);
 
 

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -12,6 +12,8 @@ typedef struct _command_line_history_t {
     uint32_t cursor_offset;   // Offset into command_line_history_t.buf where the cursor is currently positioned
     char buf[UI_CMDBUFFSIZE]; // Global circular buffer used to store command line input and history
 } command_line_history_t;
+
+// Global used for main command line input from COM / UART terminal
 extern command_line_history_t cmdln;
 
 // This structure is used to track a single "command" and all options associated with that command.
@@ -168,7 +170,7 @@ inline bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* 
 #pragma endregion // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
 
 
-// TODO: Remove this once rotate operation implemented so command line always starts at offset zero
+// TODO: Remove this, once rotate operation implemented (sets command line to always starts at offset zero)
 uint32_t cmdln_pu(uint32_t i);
 
 

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -17,41 +17,54 @@ typedef struct _command_line_history_t {
 // At present, multiple commands can be entered in a single command line,
 // and this structure will define the offsets to a single one of those commands.
 
-// TODO: rename this structure to avoid confusion between pointers / offsets ... maybe `_command_extent`?
-typedef struct _command_pointer_t {
-    uint32_t wptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
-    uint32_t rptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
-} command_pointer_t;
-
 // TODO: document the fields in this structure
 // WARNING: the end offset might EXCEED UI_CMDBUFFSIZE?!  Change to be a character count instead of end offset?
 // WARNING: Some fields are modulo'd by UI_CMDBUFFSIZE, others are NOT.  This is just asking for bugs....
 typedef struct _command_info_t {
-    uint32_t rptr;     // NOT a pointer .. this is an offset into member .buf (a circular buffer)
-    uint32_t wptr;     // NOT a pointer .. this is an offset into member .buf (a circular buffer)
-    uint32_t startptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
-    uint32_t endptr;   // NOT a pointer .. this is an offset into member .buf (a circular buffer)
-    uint32_t nextptr;  // NOT a pointer .. this is an offset into member .buf (a circular buffer)
-    char delimiter;
+    // Maybe include a pointer to the `command_line_history_t` that this refers to?
+    // Since this structure has no meaning without  that context...
+    command_line_history_t * history; // pointer to the command line history structure for this command_info_t
+    uint32_t rptr;     // NOT a pointer .. this is an offset into command history .buf (a circular buffer)
+    uint32_t wptr;     // NOT a pointer .. this is an offset into command history .buf (a circular buffer)
+    uint32_t startptr; // NOT a pointer .. this is an offset into command history .buf (a circular buffer)
+    uint32_t endptr;   // NOT a pointer .. this is an offset into command history .buf (a circular buffer)
+    uint32_t nextptr;  // NOT a pointer .. this is an offset into command history .buf (a circular buffer)
+    char delimiter;    // Is this command part of a chain?  e.g., `;`, `||`, '&&` -- 0 means no, else stores a single-char version of the delimiter
     char command[9];   // BUGBUG -- Hard-coded buffer size ... should this be MAX_COMMAND_LENGTH?
 } command_info_t;
 
-void cmdln_init(command_line_history_t* out_cmdln);
-void cmdln_init_command_info(command_info_t* out_cmdinfo);
+// TODO: rename this structure to avoid confusion between pointers / offsets ... maybe `command_extent_t` or `single_command_t`?
 
-bool cmdline_validate_invariants_command_line(const command_line_history_t * cmdline);
+// This is a short-lived structure that will become invalid anytime the history is modified.
+// TODO: add way to assert that the history matches ... maybe a simple edit counter in the command_line_history_t struct,
+//       which is copied into this structure when it is initialized?
+//       then, can assert that the edit counters match before relying on the data.
+//       this will catch really tricky bugs much more rapidly.
+typedef struct _command_pointer_t {
+    command_line_history_t const * history; // can this be a pointer to a const?
+    uint32_t rptr; // Initialized to history->read_offset;  Use as: history[buf + this->read_offset]
+    uint32_t wptr; // Initialized to history->read_offset;  Use as: history[buf + this->read_offset]
+} command_pointer_t;
+
+
+
+void cmdln_init(command_line_history_t* out_cmdln);
+void cmdln_init_command_info(command_line_history_t* command_line_history, command_info_t* out_cmdinfo);
+void cmdln_init_command_pointer(command_line_history_t* command_line_history, command_pointer_t* out_cmdinfo);
+
+bool cmdline_validate_invariants_command_line_history(const command_line_history_t * cmdline);
 bool cmdline_validate_invariants_command_pointer(const command_pointer_t * cp);
 bool cmdline_validate_invariants_command_info(const command_info_t * cmdinfo);
 
 // Yes, this is syntactic sugar.
 #define cmdline_validate_invariants(X) \
     _Generic((X),                  \
-        command_pointer_t *       : cmdline_validate_invariants_command_pointer, \
-        const command_pointer_t * : cmdline_validate_invariants_command_pointer, \
-        command_line_history_t *          : cmdline_validate_invariants_command_line, \
-        const command_line_history_t *    : cmdline_validate_invariants_command_line, \
-        command_info_t *          : cmdline_validate_invariants_command_info, \
-        const command_info_t *    : cmdline_validate_invariants_command_info  \
+        command_pointer_t *             : cmdline_validate_invariants_command_pointer,      \
+        const command_pointer_t *       : cmdline_validate_invariants_command_pointer,      \
+        command_line_history_t *        : cmdline_validate_invariants_command_line_history, \
+        const command_line_history_t *  : cmdline_validate_invariants_command_line_history, \
+        command_info_t *                : cmdline_validate_invariants_command_info,         \
+        const command_info_t *          : cmdline_validate_invariants_command_info          \
         )(X)
 
 
@@ -64,18 +77,52 @@ typedef struct command_var_struct {
     uint8_t number_format;
 } command_var_t;
 
+////////////////////////////////////////////////////////////////////////////////////////
+// TODO: update to use these new versions of the functions
+////////////////////////////////////////////////////////////////////////////////////////
+bool cmdln_args_find_flag_ex(command_info_t* cp, char flag);
+bool cmdln_args_find_flag_uint32_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t* value);
+bool cmdln_args_find_flag_string_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t max_len, char* str);
+bool cmdln_args_float_by_position_ex(command_info_t* cp, uint32_t pos, float* value);
+bool cmdln_args_uint32_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t* value);
+bool cmdln_args_string_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t max_len, char* str);
+
+bool cmdln_try_add_ex(command_line_history_t * command_line_history, char* c);
+bool cmdln_try_remove_ex(command_line_history_t * command_line_history, char* c);
+bool cmdln_try_peek_ex(command_line_history_t const * command_line_history, uint32_t i, char* c);
+bool cmdln_try_discard_ex(command_line_history_t* command_history_buffer, uint32_t i);
+bool cmdln_next_buf_pos_ex(command_line_history_t* command_history_buffer);
+
+// this one is already OK, once we track the .history field
+// bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
+
+bool cmdln_info_ex(command_line_history_t* command_history_buffer);
+bool cmdln_info_uint32_ex(command_line_history_t* command_history_buffer);
+
+
+
+////////////////////////////////////////////////////////////////////////////////////////
+// TODO: update these to be inline functions for the ...ex() versions
+////////////////////////////////////////////////////////////////////////////////////////
 bool cmdln_args_find_flag(char flag);
 bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value);
 bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str);
 bool cmdln_args_float_by_position(uint32_t pos, float* value);
 bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value);
 bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str);
+
+
+// Finds the next command (if any) in the current single line of command input
 bool cmdln_find_next_command(command_info_t* cp);
+
+// Debug functions to dump state to debugger
 bool cmdln_info(void);
 bool cmdln_info_uint32(void);
 
-// update a command line buffer offset with rollover -- (i.e., modulo operator due to circular buffer)
+// TODO: Remove this once rotate operation implemented
 uint32_t cmdln_pu(uint32_t i);
+
+
 // try to add a byte to the command line buffer, return false if buffer full
 bool cmdln_try_add(char* c);
 // try to get a byte, return false if buffer empty
@@ -94,11 +141,9 @@ bool cmdln_try_discard(uint32_t i);
 // this moves the read offset to the write offset,
 // allowing the next command line to be entered after the previous.
 // this allows the history scroll through the circular buffer
-bool cmdln_next_buf_pos(void);
+bool cmdln_next_buf_pos(); // TODO: Rename this API to more clearly indicate its purpose
 
-// TODO: rename this API to avoid confusion about pointers / offsets
+
 bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
-// TODO: rename this API to avoid confusion about pointers / offsets
-void cmdln_get_command_pointer(command_line_history_t const * command_line_history, command_pointer_t* cp);
 
 extern command_line_history_t cmdln;

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -6,7 +6,7 @@
 // When read and write offsets are equal, the buffer is empty.
 // Read and write offsets should ALWAYS be between 0 and UI_CMDBUFFSIZE-1.
 struct _command_line {
-    uint32_t wptr;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
+    uint32_t write_offset;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t rptr;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t histptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t cursptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -7,7 +7,7 @@
 // Read and write offsets should ALWAYS be between 0 and UI_CMDBUFFSIZE-1.
 struct _command_line {
     uint32_t write_offset;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
-    uint32_t rptr;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
+    uint32_t read_offset;    // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t histptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     uint32_t cursptr; // NOT a pointer .. this is an offset into member .buf (a circular buffer)
     char buf[UI_CMDBUFFSIZE];

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -36,6 +36,9 @@ typedef struct _command_info_t {
     char command[9];   // BUGBUG -- Hard-coded buffer size ... should this be MAX_COMMAND_LENGTH?
 } command_info_t;
 
+void cmdln_init(command_line_history_t* out_cmdln);
+void cmdln_init_command_info(command_info_t* out_cmdinfo);
+
 bool cmdline_validate_invariants_command_line(const command_line_history_t * cmdline);
 bool cmdline_validate_invariants_command_pointer(const command_pointer_t * cp);
 bool cmdline_validate_invariants_command_info(const command_info_t * cmdinfo);
@@ -93,11 +96,9 @@ bool cmdln_try_discard(uint32_t i);
 // this allows the history scroll through the circular buffer
 bool cmdln_next_buf_pos(void);
 
-void cmdln_init(void);
-
 // TODO: rename this API to avoid confusion about pointers / offsets
 bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
 // TODO: rename this API to avoid confusion about pointers / offsets
-void cmdln_get_command_pointer(command_pointer_t* cp);
+void cmdln_get_command_pointer(command_line_history_t const * command_line_history, command_pointer_t* cp);
 
 extern command_line_history_t cmdln;

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -140,7 +140,7 @@ inline bool cmdln_try_peek(uint32_t i, char* c) { return cmdln_try_peek_ex(&cmdl
 // try to discard n bytes (advance the read offset)
 // return false if end of buffer is reached
 // (should be used with try_peek to confirm before discarding...)
-bool cmdln_try_discard(uint32_t i);
+inline bool cmdln_try_discard(uint32_t i) { return cmdln_try_discard_ex(&cmdln, i); }
 // this moves the read offset to the write offset,
 // allowing the next command line to be entered after the previous.
 // this allows the history scroll through the circular buffer

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -102,6 +102,7 @@ bool cmdln_args_find_flag_ex(command_info_t* ci, char flag);
 bool cmdln_args_find_flag_uint32_ex(command_info_t* ci, char flag, command_var_t* arg, uint32_t* value);
 bool cmdln_args_find_flag_string_ex(command_info_t* ci, char flag, command_var_t* arg, uint32_t max_len, char* str);
 
+bool cmdln_args_float_by_position_ex(command_info_t* ci, uint32_t pos, float* value);
 
 
 // Finds the next command (if any) in the current single line of command input
@@ -133,17 +134,17 @@ bool cmdln_args_find_flag(char flag);
 bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value);
 bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str);
 
+bool cmdln_args_float_by_position(uint32_t pos, float* value);
+
 #pragma endregion // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
 
 
-bool cmdln_args_float_by_position_ex(command_info_t* ci, uint32_t pos, float* value);
 bool cmdln_args_uint32_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t* value);
 bool cmdln_args_string_by_position_ex(command_info_t* ci, uint32_t pos, uint32_t max_len, char* str);
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // TODO: update these to be inline functions for the ...ex() versions
 ////////////////////////////////////////////////////////////////////////////////////////
-bool cmdln_args_float_by_position(uint32_t pos, float* value);
 bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value);
 bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str);
 

--- a/src/ui/ui_cmdln.h
+++ b/src/ui/ui_cmdln.h
@@ -80,19 +80,10 @@ typedef struct command_var_struct {
     // clang-format on
 } command_var_t;
 
-////////////////////////////////////////////////////////////////////////////////////////
-// TODO: update to use these new versions of the functions
-////////////////////////////////////////////////////////////////////////////////////////
-bool cmdln_args_find_flag_ex(command_info_t* cp, char flag);
-bool cmdln_args_find_flag_uint32_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t* value);
-bool cmdln_args_find_flag_string_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t max_len, char* str);
-bool cmdln_args_float_by_position_ex(command_info_t* cp, uint32_t pos, float* value);
-bool cmdln_args_uint32_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t* value);
-bool cmdln_args_string_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t max_len, char* str);
+#pragma region    // Updated ..._ex() functions to exist and use parameter -- Phase 1
 
 bool cmdln_try_add_ex(command_line_history_t * command_line_history, char* c);
 bool cmdln_try_remove_ex(command_line_history_t * command_line_history, char* c);
-
 // try to peek 0+n bytes (no offsets updated)
 // returns false if at the end of the buffer
 // this should always be used sequentially from zero,
@@ -101,36 +92,24 @@ bool cmdln_try_remove_ex(command_line_history_t * command_line_history, char* c)
 // to avoid missing the end of the buffer
 bool cmdln_try_peek_ex(command_line_history_t const * command_line_history, uint32_t i, char* c);
 bool cmdln_try_discard_ex(command_line_history_t* command_history_buffer, uint32_t i);
-bool cmdln_next_buf_pos_ex(command_line_history_t* command_history_buffer);
 
-// peek at offset from a specific command_pointer_t
-bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
+bool cmdln_next_buf_pos_ex(command_line_history_t* command_history_buffer); // TODO: Rename this API to more clearly indicate its purpose
 
 // Debug function ... dump parsing of current line of input to debugger
 bool cmdln_info_ex(command_line_history_t* command_history_buffer);
 
 
-
-
-
-////////////////////////////////////////////////////////////////////////////////////////
-// TODO: update these to be inline functions for the ...ex() versions
-////////////////////////////////////////////////////////////////////////////////////////
-bool cmdln_args_find_flag(char flag);
-bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value);
-bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str);
-bool cmdln_args_float_by_position(uint32_t pos, float* value);
-bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value);
-bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str);
-
-
 // Finds the next command (if any) in the current single line of command input
 bool cmdln_find_next_command(command_info_t* cp);
+// peek at offset from a specific command_pointer_t
+bool cmdln_try_peek_pointer(command_pointer_t* cp, uint32_t i, char* c);
 
 
-// TODO: Remove this once rotate operation implemented
-uint32_t cmdln_pu(uint32_t i);
+#pragma endregion // Updated ..._ex() functions to exist and use parameter -- Phase 1
 
+#pragma region    // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
+
+// These should all be inline functions that call the ..._ex() version
 
 // try to add a byte to the command line buffer, return false if buffer full
 inline bool cmdln_try_add(char* c) { return cmdln_try_add_ex(&cmdln, c); }
@@ -144,7 +123,34 @@ inline bool cmdln_try_discard(uint32_t i) { return cmdln_try_discard_ex(&cmdln, 
 // this moves the read offset to the write offset,
 // allowing the next command line to be entered after the previous.
 // this allows the history scroll through the circular buffer
-bool cmdln_next_buf_pos(); // TODO: Rename this API to more clearly indicate its purpose
+inline bool cmdln_next_buf_pos() { return cmdln_next_buf_pos_ex(&cmdln); } 
+#pragma endregion // TO BE DEPRECATED AND/OR REMOVED -- Phase 2
+
+
+bool cmdln_args_find_flag_ex(command_info_t* cp, char flag);
+bool cmdln_args_find_flag_uint32_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t* value);
+bool cmdln_args_find_flag_string_ex(command_info_t* cp, char flag, command_var_t* arg, uint32_t max_len, char* str);
+bool cmdln_args_float_by_position_ex(command_info_t* cp, uint32_t pos, float* value);
+bool cmdln_args_uint32_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t* value);
+bool cmdln_args_string_by_position_ex(command_info_t* cp, uint32_t pos, uint32_t max_len, char* str);
+bool cmdln_find_next_command(command_info_t* cp);
+
+////////////////////////////////////////////////////////////////////////////////////////
+// TODO: update these to be inline functions for the ...ex() versions
+////////////////////////////////////////////////////////////////////////////////////////
+bool cmdln_args_find_flag(char flag);
+bool cmdln_args_find_flag_uint32(char flag, command_var_t* arg, uint32_t* value);
+bool cmdln_args_find_flag_string(char flag, command_var_t* arg, uint32_t max_len, char* str);
+bool cmdln_args_float_by_position(uint32_t pos, float* value);
+bool cmdln_args_uint32_by_position(uint32_t pos, uint32_t* value);
+bool cmdln_args_string_by_position(uint32_t pos, uint32_t max_len, char* str);
+
+
+
+// TODO: Remove this once rotate operation implemented
+uint32_t cmdln_pu(uint32_t i);
+
+
 
 
 

--- a/src/ui/ui_help.h
+++ b/src/ui/ui_help.h
@@ -1,6 +1,6 @@
 typedef struct ui_help_options {
     uint help;             // should be a section handling designator
-    const char command[9]; // ugh
+    const char command[9]; // ugh -- BUGBUG -- should this be MAX_COMMAND_LENGTH???
     uint description;      // translation key
 } ui_help_options_t;
 

--- a/src/ui/ui_init.c
+++ b/src/ui/ui_init.c
@@ -12,5 +12,5 @@
 
 // initializes the ui variables
 void ui_init(void) {
-    cmdln_init(&cmdln);
+    cmdln_init_command_history(&cmdln);
 }

--- a/src/ui/ui_init.c
+++ b/src/ui/ui_init.c
@@ -12,5 +12,5 @@
 
 // initializes the ui variables
 void ui_init(void) {
-    cmdln_init();
+    cmdln_init(&cmdln);
 }

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -285,15 +285,15 @@ bool ui_parse_get_bool(struct prompt_result* result, bool* value) {
 //bool ui_parse_get_bool(struct prompt_result* result, bool* value)
 
 // get a float from user input
-bool ui_parse_get_float(struct prompt_result* result, float* value) {
+bool ui_parse_get_float_ex(command_line_history_t * history, struct prompt_result* result, float* value) {
     uint32_t number = 0;
     uint32_t decimal = 0;
     int j = 0;
-    bool r;
-    char c;
+    bool r = false;
+    char c = 0;
     *result = empty_result; // initialize result with empty result
 
-    r = cmdln_try_peek(0, &c);
+    r = cmdln_try_peek_ex(history, 0, &c);
     if (!r || c == 0x00) // user pressed enter only
     {
         result->no_value = true;
@@ -304,13 +304,13 @@ bool ui_parse_get_float(struct prompt_result* result, float* value) {
     {
         if ((c >= '0') && (c <= '9')) // there is a number before the . or ,
         {
-            ui_parse_get_dec(result, &number);
+            ui_parse_get_dec_ex(history, result, &number);
         }
 
-        r = cmdln_try_peek(0, &c);
+        r = cmdln_try_peek_ex(history, 0, &c);
         if (r && (c == '.' || c == ',')) {
-            cmdln_try_discard(1);         // discard seperator
-            while (cmdln_try_peek(0, &c)) // peek at next char
+            cmdln_try_discard_ex(history, 1);         // discard seperator
+            while (cmdln_try_peek_ex(history, 0, &c)) // peek at next char
             {
                 if ((c < '0') || (c > '9')) // if there is a char, and it is in range
                 {
@@ -319,7 +319,7 @@ bool ui_parse_get_float(struct prompt_result* result, float* value) {
 
                 decimal *= 10;
                 decimal += (c - 0x30);
-                cmdln_try_discard(1); // discard
+                cmdln_try_discard_ex(history, 1); // discard
                 j++;                  // track digits so we can find the proper divider later...
             }
         }
@@ -336,7 +336,9 @@ bool ui_parse_get_float(struct prompt_result* result, float* value) {
 
     return true;
 }
-//bool ui_parse_get_float(struct prompt_result* result, float* value)
+bool ui_parse_get_float(struct prompt_result* result, float* value) {
+    return ui_parse_get_float_ex(&cmdln, result, value);
+}
 
 bool ui_parse_get_uint32_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value) {
     bool r = false;

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -148,8 +148,8 @@ bool ui_parse_get_string(struct prompt_result* result, char* str, uint8_t* size)
 
 // eats up the spaces and comma's from the cmdline
 void ui_parse_consume_whitespace(void) {
-    while ((cmdln.rptr != cmdln.write_offset) && ((cmdln.buf[cmdln.rptr] == ' ') || (cmdln.buf[cmdln.rptr] == ','))) {
-        cmdln.rptr = cmdln_pu(cmdln.rptr + 1);
+    while ((cmdln.read_offset != cmdln.write_offset) && ((cmdln.buf[cmdln.read_offset] == ' ') || (cmdln.buf[cmdln.read_offset] == ','))) {
+        cmdln.read_offset = cmdln_pu(cmdln.read_offset + 1);
     }
 }
 

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -188,20 +188,24 @@ bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value) {
 }
 
 // get the repeat from the commandline (if any) XX:repeat
-bool ui_parse_get_colon(uint32_t* value) {
+bool ui_parse_get_colon_ex(command_line_history_t * history, uint32_t* value) {
     prompt_result result;
-    ui_parse_get_delimited_sequence(&result, ':', value);
+    ui_parse_get_delimited_sequence_ex(history, &result, ':', value);
     return result.success;
 }
-//bool ui_parse_get_colon(uint32_t* value)
+bool ui_parse_get_colon(uint32_t* value) {
+    return ui_parse_get_colon_ex(&cmdln, value);
+}
 
 // get the number of bits from the commandline (if any) XXX.numbit
-bool ui_parse_get_dot(uint32_t* value) {
+bool ui_parse_get_dot_ex(command_line_history_t * history, uint32_t* value) {
     prompt_result result;
-    ui_parse_get_delimited_sequence(&result, '.', value);
+    ui_parse_get_delimited_sequence_ex(history, &result, '.', value);
     return result.success;
 }
-//bool ui_parse_get_dot(uint32_t* value)
+bool ui_parse_get_dot(uint32_t* value) {
+    return ui_parse_get_dot_ex(&cmdln, value);
+}
 
 // get trailing information for a command, for example :10 or .10
 bool ui_parse_get_delimited_sequence_ex(command_line_history_t * history, struct prompt_result* result, char delimiter, uint32_t* value) {

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -254,14 +254,14 @@ bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8
 }
 //bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8_t len)
 
-bool ui_parse_get_bool(struct prompt_result* result, bool* value) {
+bool ui_parse_get_bool_ex(command_line_history_t * history, struct prompt_result* result, bool* value) {
 
-    bool r;
-    char c;
+    bool r = false;
+    char c = 0;
 
     *result = empty_result; // initialize result with empty result
 
-    r = cmdln_try_peek(0, &c);
+    r = cmdln_try_peek_ex(history, 0, &c);
     if (!r || c == 0x00) // user pressed enter only
     {
         result->no_value = true;
@@ -279,10 +279,12 @@ bool ui_parse_get_bool(struct prompt_result* result, bool* value) {
     {
         result->error = true;
     }
-    cmdln_try_discard(1); // discard
+    cmdln_try_discard_ex(history, 1); // discard
     return true;
 }
-//bool ui_parse_get_bool(struct prompt_result* result, bool* value)
+bool ui_parse_get_bool(struct prompt_result* result, bool* value) {
+    return ui_parse_get_bool_ex(&cmdln, result, value);
+}
 
 // get a float from user input
 bool ui_parse_get_float_ex(command_line_history_t * history, struct prompt_result* result, float* value) {

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -168,13 +168,14 @@ void ui_parse_consume_whitespace(void) {
     ui_parse_consume_whitespace_ex(&cmdln);
 }
 
-bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value) {
-    char c;
-    bool r;
+bool ui_parse_get_macro_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value) {
+    char c = 0;
+    bool r = false;
 
     // cmdln_try_discard(1); // advance 1 position '('
-    ui_parse_get_int(result, value); // get number
-    r = cmdln_try_remove(&c);        // advance 1 position ')'
+    // BUGBUG -- return value is ignored!
+    ui_parse_get_int_ex(history, result, value); // get number
+    r = cmdln_try_remove_ex(history, &c);        // advance 1 position ')'
     if (r && c == ')') {
         result->success = true;
     } else {
@@ -182,7 +183,9 @@ bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value) {
     }
     return result->success;
 }
-//bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value)
+bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value) {
+    return ui_parse_get_macro_ex(&cmdln, result, value);
+}
 
 // get the repeat from the commandline (if any) XX:repeat
 bool ui_parse_get_colon(uint32_t* value) {

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -148,7 +148,7 @@ bool ui_parse_get_string(struct prompt_result* result, char* str, uint8_t* size)
 
 // eats up the spaces and comma's from the cmdline
 void ui_parse_consume_whitespace(void) {
-    while ((cmdln.rptr != cmdln.wptr) && ((cmdln.buf[cmdln.rptr] == ' ') || (cmdln.buf[cmdln.rptr] == ','))) {
+    while ((cmdln.rptr != cmdln.write_offset) && ((cmdln.buf[cmdln.rptr] == ' ') || (cmdln.buf[cmdln.rptr] == ','))) {
         cmdln.rptr = cmdln_pu(cmdln.rptr + 1);
     }
 }

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -1,3 +1,6 @@
+#define BP_DEBUG_OVERRIDE_DEFAULT_CATEGORY BP_DEBUG_CAT_CMDLINE_PARSER
+#define BP_NO_LEGACY_CMDLINE_FUNCTIONS
+
 #include <stdio.h>
 #include "pico/stdlib.h"
 #include <stdint.h>
@@ -10,8 +13,8 @@
 #include "ui/ui_cmdln.h"
 
 // remove definition of `cmdln` global ..
-// to detect inadvertent use, as these functions
-// should **_NOT_** touch global state anymore
+// to detect inadvertent use in this file,
+// as these functions should **_NOT_** touch global state
 #undef cmdln
 
 // TODO: UI_CMDBUFFSIZE is globally defined, and therefore
@@ -344,18 +347,18 @@ bool ui_parse_get_units_ex(command_line_history_t * history, struct prompt_resul
     *result = empty_result;
 
     // get the trailing type
-    ui_parse_consume_whitespace();
+    ui_parse_consume_whitespace_ex(history);
 
     for (i = 0; i < length; i++) {
         units[i] = 0x00;
     }
 
     i = 0;
-    while (cmdln_try_peek(0, &c)) {
+    while (cmdln_try_peek_ex(history, 0, &c)) {
         if ((i < length) && c != 0x00 && c != ' ') {
             units[i] = (c | 0x20); // to lower case
             i++;
-            cmdln_try_discard(1);
+            cmdln_try_discard_ex(history, 1);
         } else {
             break;
         }

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -238,13 +238,13 @@ bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimite
 
 // some commands have trailing attributes like m 6, o 4 etc
 // get as many as specified or error....
-bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8_t len) {
+bool ui_parse_get_attributes_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* attr, uint8_t len) {
     *result = empty_result;
     result->no_value = true;
 
     for (uint8_t i = 0; i < len; i++) {
-        ui_parse_consume_whitespace(); // eat whitechars
-        ui_parse_get_uint32(result, &attr[i]);
+        ui_parse_consume_whitespace_ex(history); // eat whitechars
+        ui_parse_get_uint32_ex(history, result, &attr[i]);
         if (result->error || result->no_value) {
             return false;
         }
@@ -252,7 +252,9 @@ bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8
 
     return true;
 }
-//bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8_t len)
+bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8_t len) {
+    return ui_parse_get_attributes_ex(&cmdln, result, attr, len);
+}
 
 bool ui_parse_get_bool_ex(command_line_history_t * history, struct prompt_result* result, bool* value) {
 

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -204,20 +204,21 @@ bool ui_parse_get_dot(uint32_t* value) {
 //bool ui_parse_get_dot(uint32_t* value)
 
 // get trailing information for a command, for example :10 or .10
-bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimiter, uint32_t* value) {
+bool ui_parse_get_delimited_sequence_ex(command_line_history_t * history, struct prompt_result* result, char delimiter, uint32_t* value) {
     char c;
     *result = empty_result;
 
-    if (cmdln_try_peek(0, &c)) // advance one, did we reach the end?
+    if (cmdln_try_peek_ex(history, 0, &c)) // advance one, did we reach the end?
     {
         if (c == delimiter) // we have a change in bits \o/
         {
             // check that the next char is actually numeric before continue
-            //  prevents eating consecutive .... s
-            if (cmdln_try_peek(1, &c)) {
+            //  prevents eating consecutive ....
+            if (cmdln_try_peek_ex(history, 1, &c)) {
                 if (c >= '0' && c <= '9') {
-                    cmdln_try_discard(1); // discard delimiter
-                    ui_parse_get_int(result, value);
+                    cmdln_try_discard_ex(history, 1); // discard delimiter
+                    // BUGBUG -- ignores return value
+                    ui_parse_get_int_ex(history, result, value);
                     result->success = true;
                     return true;
                 }
@@ -227,7 +228,9 @@ bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimite
     result->no_value = true;
     return false;
 }
-//bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimiter, uint32_t* value)
+bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimiter, uint32_t* value) {
+    return ui_parse_get_delimited_sequence_ex(&cmdln, result, delimiter, value);
+}
 
 // some commands have trailing attributes like m 6, o 4 etc
 // get as many as specified or error....

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -338,13 +338,13 @@ bool ui_parse_get_float(struct prompt_result* result, float* value) {
 }
 //bool ui_parse_get_float(struct prompt_result* result, float* value)
 
-bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value) {
-    bool r;
-    char c;
+bool ui_parse_get_uint32_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value) {
+    bool r = false;
+    char c = 0;
 
     *result = empty_result; // initialize result with empty result
 
-    r = cmdln_try_peek(0, &c);
+    r = cmdln_try_peek_ex(history, 0, &c);
     if (!r || c == 0x00) // user pressed enter only
     {
         result->no_value = true;
@@ -353,15 +353,17 @@ bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value) {
         result->exit = true;
     } else if ((c >= '0') && (c <= '9')) // 1-9 decimal
     {
-        return ui_parse_get_dec(result, value);
+        return ui_parse_get_dec_ex(history, result, value);
     } else // bad result (not number)
     {
         result->error = true;
     }
-    cmdln_try_discard(1); // discard
+    cmdln_try_discard_ex(history, 1); // discard
     return true;
 }
-// bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value)
+bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value) {
+    return ui_parse_get_uint32_ex(&cmdln, result, value);
+}
 
 bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type) {
     char c;

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -159,10 +159,13 @@ bool ui_parse_get_string(struct prompt_result* result, char* str, uint8_t* size)
 }
 
 // eats up the spaces and comma's from the cmdline
-void ui_parse_consume_whitespace(void) {
-    while ((cmdln.read_offset != cmdln.write_offset) && ((cmdln.buf[cmdln.read_offset] == ' ') || (cmdln.buf[cmdln.read_offset] == ','))) {
-        cmdln.read_offset = cmdln_pu(cmdln.read_offset + 1);
+void ui_parse_consume_whitespace_ex(command_line_history_t* history) {
+    while ((history->read_offset != history->write_offset) && ((history->buf[history->read_offset] == ' ') || (history->buf[history->read_offset] == ','))) {
+        history->read_offset = cmdln_pu(history->read_offset + 1);
     }
+}
+void ui_parse_consume_whitespace(void) {
+    ui_parse_consume_whitespace_ex(&cmdln);
 }
 
 bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value) {
@@ -179,6 +182,7 @@ bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value) {
     }
     return result->success;
 }
+//bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value)
 
 // get the repeat from the commandline (if any) XX:repeat
 bool ui_parse_get_colon(uint32_t* value) {
@@ -186,6 +190,7 @@ bool ui_parse_get_colon(uint32_t* value) {
     ui_parse_get_delimited_sequence(&result, ':', value);
     return result.success;
 }
+//bool ui_parse_get_colon(uint32_t* value)
 
 // get the number of bits from the commandline (if any) XXX.numbit
 bool ui_parse_get_dot(uint32_t* value) {
@@ -193,6 +198,7 @@ bool ui_parse_get_dot(uint32_t* value) {
     ui_parse_get_delimited_sequence(&result, '.', value);
     return result.success;
 }
+//bool ui_parse_get_dot(uint32_t* value)
 
 // get trailing information for a command, for example :10 or .10
 bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimiter, uint32_t* value) {
@@ -218,6 +224,7 @@ bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimite
     result->no_value = true;
     return false;
 }
+//bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimiter, uint32_t* value)
 
 // some commands have trailing attributes like m 6, o 4 etc
 // get as many as specified or error....
@@ -235,6 +242,7 @@ bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8
 
     return true;
 }
+//bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8_t len)
 
 bool ui_parse_get_bool(struct prompt_result* result, bool* value) {
 
@@ -264,6 +272,7 @@ bool ui_parse_get_bool(struct prompt_result* result, bool* value) {
     cmdln_try_discard(1); // discard
     return true;
 }
+//bool ui_parse_get_bool(struct prompt_result* result, bool* value)
 
 // get a float from user input
 bool ui_parse_get_float(struct prompt_result* result, float* value) {
@@ -317,6 +326,7 @@ bool ui_parse_get_float(struct prompt_result* result, float* value) {
 
     return true;
 }
+//bool ui_parse_get_float(struct prompt_result* result, float* value)
 
 bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value) {
     bool r;
@@ -341,6 +351,7 @@ bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value) {
     cmdln_try_discard(1); // discard
     return true;
 }
+// bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value)
 
 bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type) {
     char c;
@@ -396,3 +407,4 @@ bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t lengt
     result->success = true;
     return true;
 }
+// bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type)

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -7,7 +7,18 @@
 #include "ui/ui_prompt.h" //needed for prompt_result struct
 #include "ui/ui_parse.h"
 #include "ui/ui_const.h"
-#include "ui/ui_cmdln.h" // This defines `cmdln` global .. which should *NOT* be used here!
+#include "ui/ui_cmdln.h"
+
+// remove definition of `cmdln` global ..
+// to detect inadvertent use, as these functions
+// should **_NOT_** touch global state anymore
+#undef cmdln
+
+// TODO: UI_CMDBUFFSIZE is globally defined, and therefore
+//       ANY command_line_history_t must have identical buffer
+//       size.  When memory pressure hits, revisit this.
+//       See UI_CMDBUFFSIZE
+//       See cmdln_pu() ... which rolls-over the buffer pointer
 
 
 static const struct prompt_result empty_result;
@@ -31,15 +42,12 @@ bool ui_parse_get_hex_ex(command_line_history_t * history, struct prompt_result*
         } else {
             return false;
         }
-        cmdln_try_discard(1); // discard
+        cmdln_try_discard_ex(history, 1); // discard
         result->success = true;
         result->no_value = false;
     }
 
     return result->success;
-}
-bool ui_parse_get_hex(struct prompt_result* result, uint32_t* value) {
-    return ui_parse_get_hex_ex(&cmdln, result, value);
 }
 bool ui_parse_get_bin_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value) {
     char c;

--- a/src/ui/ui_parse.c
+++ b/src/ui/ui_parse.c
@@ -371,7 +371,7 @@ bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value) {
     return ui_parse_get_uint32_ex(&cmdln, result, value);
 }
 
-bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type) {
+bool ui_parse_get_units_ex(command_line_history_t * history, struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type) {
     char c;
     uint8_t i = 0;
     *result = empty_result;
@@ -425,4 +425,6 @@ bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t lengt
     result->success = true;
     return true;
 }
-// bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type)
+bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type) {
+    return ui_parse_get_units_ex(&cmdln, result, units, length, unit_type);
+}

--- a/src/ui/ui_parse.h
+++ b/src/ui/ui_parse.h
@@ -1,4 +1,30 @@
+#pragma once
 
+#include <ui/ui_cmdln.h>
+
+// gets all number accepted formats
+bool ui_parse_get_int_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value);
+
+// get DEC (base 10) with eXit option
+bool ui_parse_get_uint32_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value);
+
+bool ui_parse_get_string_ex(command_line_history_t * history, struct prompt_result* result, char* str, uint8_t* size);
+
+// get float with eXit option
+bool ui_parse_get_float_ex(command_line_history_t * history, struct prompt_result* result, float* value);
+
+bool ui_parse_get_delimited_sequence_ex(command_line_history_t * history, struct prompt_result* result, char delimiter, uint32_t* value);
+bool ui_parse_get_units_ex(command_line_history_t * history, struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type);
+bool ui_parse_get_macro_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value);
+bool ui_parse_get_attributes_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* attr, uint8_t len);
+bool ui_parse_get_bool_ex(command_line_history_t * history, struct prompt_result* result, bool* value);
+bool ui_parse_get_colon_ex(command_line_history_t * history, uint32_t* value);
+bool ui_parse_get_dot_ex(command_line_history_t * history, uint32_t* value);
+void ui_parse_consume_whitespace_ex(command_line_history_t * history);
+
+
+// These are the old UI parsing functions, which presumed a single command line history buffer / current command line
+// These need to be updated to have the command line history buffer passed in as a parameter.
 
 // gets all number accepted formats
 bool ui_parse_get_int(struct prompt_result* result, uint32_t* value);

--- a/src/ui/ui_parse.h
+++ b/src/ui/ui_parse.h
@@ -2,17 +2,16 @@
 
 #include <ui/ui_cmdln.h>
 
+
 // gets all number accepted formats
 bool ui_parse_get_int_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value);
-
+// BUGBUG -- rename this to reflect it also accepts eXit option!
 // get DEC (base 10) with eXit option
 bool ui_parse_get_uint32_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value);
-
 bool ui_parse_get_string_ex(command_line_history_t * history, struct prompt_result* result, char* str, uint8_t* size);
-
+// BUGBUG -- rename this to reflect it also accepts eXit option!
 // get float with eXit option
 bool ui_parse_get_float_ex(command_line_history_t * history, struct prompt_result* result, float* value);
-
 bool ui_parse_get_delimited_sequence_ex(command_line_history_t * history, struct prompt_result* result, char delimiter, uint32_t* value);
 bool ui_parse_get_units_ex(command_line_history_t * history, struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type);
 bool ui_parse_get_macro_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value);
@@ -22,27 +21,49 @@ bool ui_parse_get_colon_ex(command_line_history_t * history, uint32_t* value);
 bool ui_parse_get_dot_ex(command_line_history_t * history, uint32_t* value);
 void ui_parse_consume_whitespace_ex(command_line_history_t * history);
 
+#if !defined(BP_UI_PARSE_NO_LEGACY_FUNCTIONS)
 
-// These are the old UI parsing functions, which presumed a single command line history buffer / current command line
-// These need to be updated to have the command line history buffer passed in as a parameter.
+// These are the old UI parsing functions, which presumed
+// a single command line history buffer / current command line.
+// Callers of these functions need to be updated to have the
+// command line history buffer passed in as a parameter, using
+// the ..._ex() version of the function.
 
-// gets all number accepted formats
-bool ui_parse_get_int(struct prompt_result* result, uint32_t* value);
+inline bool ui_parse_get_int(struct prompt_result* result, uint32_t* value) {
+    return ui_parse_get_int_ex(&cmdln, result, value);
+}
+inline bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value) {
+    return ui_parse_get_uint32_ex(&cmdln, result, value);
+}
+inline bool ui_parse_get_string(struct prompt_result* result, char* str, uint8_t* size) {
+    return ui_parse_get_string_ex(&cmdln, result, str, size);
+}
+inline bool ui_parse_get_float(struct prompt_result* result, float* value) {
+    return ui_parse_get_float_ex(&cmdln, result, value);
+}
+inline bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimiter, uint32_t* value) {
+    return ui_parse_get_delimited_sequence_ex(&cmdln, result, delimiter, value);
+}
+inline bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type) {
+    return ui_parse_get_units_ex(&cmdln, result, units, length, unit_type);
+}
+inline bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value) {
+    return ui_parse_get_macro_ex(&cmdln, result, value);
+}
+inline bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8_t len) {
+    return ui_parse_get_attributes_ex(&cmdln, result, attr, len);
+}
+inline bool ui_parse_get_bool(struct prompt_result* result, bool* value) {
+    return ui_parse_get_bool_ex(&cmdln, result, value);
+}
+inline bool ui_parse_get_colon(uint32_t* value) {
+    return ui_parse_get_colon_ex(&cmdln, value);
+}
+inline bool ui_parse_get_dot(uint32_t* value) {
+    return ui_parse_get_dot_ex(&cmdln, value);
+}
+inline void ui_parse_consume_whitespace(void) {
+    ui_parse_consume_whitespace_ex(&cmdln);
+}
 
-// get DEC (base 10) with eXit option
-bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value);
-
-bool ui_parse_get_string(struct prompt_result* result, char* str, uint8_t* size);
-
-// get float with eXit option
-bool ui_parse_get_float(struct prompt_result* result, float* value);
-bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimiter, uint32_t* value);
-bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type);
-bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value);
-bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8_t len);
-bool ui_parse_get_bool(struct prompt_result* result, bool* value);
-
-bool ui_parse_get_colon(uint32_t* value);
-bool ui_parse_get_dot(uint32_t* value);
-
-void ui_parse_consume_whitespace(void);
+#endif // BP_UI_PARSE_NO_LEGACY_FUNCTIONS

--- a/src/ui/ui_parse.h
+++ b/src/ui/ui_parse.h
@@ -22,52 +22,74 @@ bool ui_parse_get_colon_ex(command_line_history_t * history, uint32_t* value);
 bool ui_parse_get_dot_ex(command_line_history_t * history, uint32_t* value);
 void ui_parse_consume_whitespace_ex(command_line_history_t * history);
 
-#if !defined(BP_NO_LEGACY_CMDLINE_FUNCTIONS)
+#if defined(BP_NO_LEGACY_CMDLINE_FUNCTIONS)
+    // nothing ... compile error is using them
+#else
+    // These are the old UI parsing functions, which presumed
+    // a single command line history buffer / current command line.
+    // Callers of these functions need to be updated to have the
+    // command line history buffer passed in as a parameter, using
+    // the ..._ex() version of the function.
 
-// These are the old UI parsing functions, which presumed
-// a single command line history buffer / current command line.
-// Callers of these functions need to be updated to have the
-// command line history buffer passed in as a parameter, using
-// the ..._ex() version of the function.
+    //#define BP_WARN_LEGACY_CMDLINE_FUNCTIONS
+    #if defined(BP_WARN_LEGACY_CMDLINE_FUNCTIONS)
+        #define BP_DEPRECATED(msg) [[deprecated(msg)]]
+    #else
+        #define BP_DEPRECATED(msg)
+    #endif
 
-inline bool ui_parse_get_int(struct prompt_result* result, uint32_t* value) {
-    return ui_parse_get_int_ex(&cmdln, result, value);
-}
-inline bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value) {
-    return ui_parse_get_uint32_ex(&cmdln, result, value);
-}
-inline bool ui_parse_get_string(struct prompt_result* result, char* str, uint8_t* size) {
-    return ui_parse_get_string_ex(&cmdln, result, str, size);
-}
-inline bool ui_parse_get_float(struct prompt_result* result, float* value) {
-    return ui_parse_get_float_ex(&cmdln, result, value);
-}
-inline bool ui_parse_get_hex(struct prompt_result* result, uint32_t* value) {
-    return ui_parse_get_hex_ex(&cmdln, result, value);
-}
-inline bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimiter, uint32_t* value) {
-    return ui_parse_get_delimited_sequence_ex(&cmdln, result, delimiter, value);
-}
-inline bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type) {
-    return ui_parse_get_units_ex(&cmdln, result, units, length, unit_type);
-}
-inline bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value) {
-    return ui_parse_get_macro_ex(&cmdln, result, value);
-}
-inline bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8_t len) {
-    return ui_parse_get_attributes_ex(&cmdln, result, attr, len);
-}
-inline bool ui_parse_get_bool(struct prompt_result* result, bool* value) {
-    return ui_parse_get_bool_ex(&cmdln, result, value);
-}
-inline bool ui_parse_get_colon(uint32_t* value) {
-    return ui_parse_get_colon_ex(&cmdln, value);
-}
-inline bool ui_parse_get_dot(uint32_t* value) {
-    return ui_parse_get_dot_ex(&cmdln, value);
-}
-inline void ui_parse_consume_whitespace(void) {
-    ui_parse_consume_whitespace_ex(&cmdln);
-}
+
+    BP_DEPRECATED("Use ui_parse_get_int() instead")
+    inline bool ui_parse_get_int(struct prompt_result* result, uint32_t* value) {
+        return ui_parse_get_int_ex(&cmdln, result, value);
+    }
+    BP_DEPRECATED("Use ui_parse_get_uint32() instead")
+    inline bool ui_parse_get_uint32(struct prompt_result* result, uint32_t* value) {
+        return ui_parse_get_uint32_ex(&cmdln, result, value);
+    }
+    BP_DEPRECATED("Use ui_parse_get_string() instead")
+    inline bool ui_parse_get_string(struct prompt_result* result, char* str, uint8_t* size) {
+        return ui_parse_get_string_ex(&cmdln, result, str, size);
+    }
+    BP_DEPRECATED("Use ui_parse_get_float() instead")
+    inline bool ui_parse_get_float(struct prompt_result* result, float* value) {
+        return ui_parse_get_float_ex(&cmdln, result, value);
+    }
+    BP_DEPRECATED("Use ui_parse_get_hex() instead")
+    inline bool ui_parse_get_hex(struct prompt_result* result, uint32_t* value) {
+        return ui_parse_get_hex_ex(&cmdln, result, value);
+    }
+    BP_DEPRECATED("Use ui_parse_get_delimited_sequence() instead")
+    inline bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimiter, uint32_t* value) {
+        return ui_parse_get_delimited_sequence_ex(&cmdln, result, delimiter, value);
+    }
+    BP_DEPRECATED("Use ui_parse_get_units() instead")
+    inline bool ui_parse_get_units(struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type) {
+        return ui_parse_get_units_ex(&cmdln, result, units, length, unit_type);
+    }
+    BP_DEPRECATED("Use ui_parse_get_macro() instead")
+    inline bool ui_parse_get_macro(struct prompt_result* result, uint32_t* value) {
+        return ui_parse_get_macro_ex(&cmdln, result, value);
+    }
+    BP_DEPRECATED("Use ui_parse_get_attributes() instead")
+    inline bool ui_parse_get_attributes(struct prompt_result* result, uint32_t* attr, uint8_t len) {
+        return ui_parse_get_attributes_ex(&cmdln, result, attr, len);
+    }
+    BP_DEPRECATED("Use ui_parse_get_bool() instead")
+    inline bool ui_parse_get_bool(struct prompt_result* result, bool* value) {
+        return ui_parse_get_bool_ex(&cmdln, result, value);
+    }
+    BP_DEPRECATED("Use ui_parse_get_colon() instead")
+    inline bool ui_parse_get_colon(uint32_t* value) {
+        return ui_parse_get_colon_ex(&cmdln, value);
+    }
+    BP_DEPRECATED("Use ui_parse_get_dot() instead")
+    inline bool ui_parse_get_dot(uint32_t* value) {
+        return ui_parse_get_dot_ex(&cmdln, value);
+    }
+    BP_DEPRECATED("Use ui_parse_consume_whitespace() instead")
+    inline void ui_parse_consume_whitespace(void) {
+        ui_parse_consume_whitespace_ex(&cmdln);
+    }
 
 #endif // BP_UI_PARSE_NO_LEGACY_FUNCTIONS

--- a/src/ui/ui_parse.h
+++ b/src/ui/ui_parse.h
@@ -12,6 +12,7 @@ bool ui_parse_get_string_ex(command_line_history_t * history, struct prompt_resu
 // BUGBUG -- rename this to reflect it also accepts eXit option!
 // get float with eXit option
 bool ui_parse_get_float_ex(command_line_history_t * history, struct prompt_result* result, float* value);
+bool ui_parse_get_hex_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value);
 bool ui_parse_get_delimited_sequence_ex(command_line_history_t * history, struct prompt_result* result, char delimiter, uint32_t* value);
 bool ui_parse_get_units_ex(command_line_history_t * history, struct prompt_result* result, char* units, uint8_t length, uint8_t* unit_type);
 bool ui_parse_get_macro_ex(command_line_history_t * history, struct prompt_result* result, uint32_t* value);
@@ -21,7 +22,7 @@ bool ui_parse_get_colon_ex(command_line_history_t * history, uint32_t* value);
 bool ui_parse_get_dot_ex(command_line_history_t * history, uint32_t* value);
 void ui_parse_consume_whitespace_ex(command_line_history_t * history);
 
-#if !defined(BP_UI_PARSE_NO_LEGACY_FUNCTIONS)
+#if !defined(BP_NO_LEGACY_CMDLINE_FUNCTIONS)
 
 // These are the old UI parsing functions, which presumed
 // a single command line history buffer / current command line.
@@ -40,6 +41,9 @@ inline bool ui_parse_get_string(struct prompt_result* result, char* str, uint8_t
 }
 inline bool ui_parse_get_float(struct prompt_result* result, float* value) {
     return ui_parse_get_float_ex(&cmdln, result, value);
+}
+inline bool ui_parse_get_hex(struct prompt_result* result, uint32_t* value) {
+    return ui_parse_get_hex_ex(&cmdln, result, value);
 }
 inline bool ui_parse_get_delimited_sequence(struct prompt_result* result, char delimiter, uint32_t* value) {
     return ui_parse_get_delimited_sequence_ex(&cmdln, result, delimiter, value);

--- a/src/ui/ui_process.c
+++ b/src/ui/ui_process.c
@@ -1,3 +1,5 @@
+#define BP_DEBUG_OVERRIDE_DEFAULT_CATEGORY BP_DEBUG_CAT_CMDLINE_PARSER
+
 #include <stdbool.h>
 #include <stdio.h>
 #include "pico/stdlib.h"
@@ -7,6 +9,7 @@
 #include "pico/multicore.h"
 #include "command_struct.h"
 #include "commands.h"
+#include "commands/global/cmd_comment.h"
 #include "bytecode.h"
 #include "modes.h"
 #include "displays.h"
@@ -69,6 +72,9 @@ SYNTAX_STATUS ui_process_syntax(void) {
 bool ui_process_macro(void) {
     uint32_t temp;
     prompt_result result;
+    // BUGBUG -- This PRESUMES that the macro is the first command.
+    // BUGBUG -- This BREAKS when the macro is the second command in a chain.
+    // BUGBUG -- This BREAKS when there are leading spaces (e.g., ` (1)`).
     cmdln_try_discard(1);
     ui_parse_get_macro(&result, &temp);
     if (result.success) {
@@ -82,7 +88,7 @@ bool ui_process_macro(void) {
 
 //returns error = true or false
 bool ui_process_commands(void) {
-    struct _command_info_t cp;
+    struct _command_info_t cp = {0};
     cp.nextptr = 0;
 
     while (true) {
@@ -90,17 +96,22 @@ bool ui_process_commands(void) {
             return false;
         }
 
-        // Special-case: these prefixes don't require space before the first argument, so only check first character is a match
+        // Special-case: these prefixes don't require space before the first argument, ***AND*** consume the entire line of input
         switch (cp.command[0]) {
-            case '[':
-            case '>':
-            case '{':
-            case ']':
-            case '}':
-                return (ui_process_syntax()==SSTATUS_ERROR)?true:false; // first character is { [ or >, process as syntax
+            case '#':
+                cmd_comment_handler(cp.startptr, cp.endptr);
+                return false; // no additional command processing after a comment ...
                 break;
             case '(':
+                // BUGBUG -- should this return from the function, or should it search for chained commands?
                 return ui_process_macro(); // first character is (, mode macro
+                break;
+            case '>':
+            case '[':
+            case ']':
+            case '{':
+            case '}':
+                return (ui_process_syntax()==SSTATUS_ERROR)?true:false; // first character is { [ or >, process as syntax
                 break;
         }
 
@@ -136,6 +147,7 @@ bool ui_process_commands(void) {
                                ui_term_color_info(),
                                GET_T(commands[user_cmd_id].help_text),
                                ui_term_color_reset());
+                        // BUGBUG -- this is not properly supporting chained commands
                         return false;
                     } else { // let app know we requested help
                         result.help_flag = true;
@@ -234,3 +246,195 @@ bool ui_process_commands(void) {
     }
     return false;
 }
+
+
+// return TRUE if command was processed, and should
+// consider chaining
+// TODO: Split this into functions for each type: global, mode, display, 
+bool ui_process_single_command_impl(struct _command_info_t const * cp, struct command_result * result) {
+
+    memcpy(&result, &result_blank, sizeof(struct command_result));
+
+    // Special-case: these prefixes don't require space before the first argument, ***AND*** consume the entire line of input
+    // Each of these if statements exits the routine early.
+    if (cp->command[0] == '#') {
+        cmd_comment_handler(cp->startptr, cp->endptr);
+        result->error = false;
+        result->success = true;
+        return true;
+    } else if (cp->command[0] == '(') {
+        bool is_err = ui_process_macro(); // first character is (, mode macro
+        result->error = is_err;
+        result->success = !is_err;
+        return true;
+    } else if (
+        (cp->command[0] == '>') ||
+        (cp->command[0] == '[') ||
+        (cp->command[0] == ']') ||
+        (cp->command[0] == '{') ||
+        (cp->command[0] == '}')  ) {
+        bool is_err = (ui_process_syntax() == SSTATUS_ERROR);
+        result->error = is_err;
+        result->success = !is_err;
+        return true;
+    }
+
+    // process as a command
+    char command_string[MAX_COMMAND_LENGTH];
+
+    // string 0 is the command
+    // continue if we don't get anything? could be an empty chained command? should that be error?
+    if (!cmdln_args_string_by_position(0, sizeof(command_string), command_string)) {
+        result->error = false;
+        result->success = true;
+        return true;
+    }
+
+    // first search global commands
+    uint32_t user_cmd_id = 0;
+    for (int i = 0; i < commands_count; i++) {
+        if (strcmp(command_string, commands[i].command) == 0) {
+            user_cmd_id = i;
+            // global help handler (optional, set config in commands.c)
+            if (cmdln_args_find_flag('h')) {
+                result->help_flag = true;
+                if (commands[user_cmd_id].help_text != 0x00) {
+                    printf("%s%s%s\r\n",
+                            ui_term_color_info(),
+                            GET_T(commands[user_cmd_id].help_text),
+                            ui_term_color_reset());
+                    result->success = true;
+                    result->error = false;
+                    return true;
+                }
+            }
+
+            // Show error about command not being available in HiZ mode,
+            // unless the command line used the `h` flag to show usage.
+            if (system_config.mode == HIZ &&
+                !commands[user_cmd_id].allow_hiz &&
+                !result->help_flag) {
+                printf("%s\r\n", hiz_error());
+                result->error = true;
+                result->success = false;
+                return true;
+            }
+            commands[user_cmd_id].func(result);
+            return true; // rely on the command itself to set result values
+        }
+    }
+
+    // if not global, search mode specific commands
+    if (modes[system_config.mode].mode_commands_count) {
+        for (int i = 0; i < *modes[system_config.mode].mode_commands_count; i++) {
+            if (strcmp(command_string, modes[system_config.mode].mode_commands[i].command) == 0) {
+                user_cmd_id = i;
+                // mode help handler
+                if (cmdln_args_find_flag('h')) {
+                    // mode commands must supply their own help text
+                    // set the flag to indicate they should do so
+                    result->help_flag = true;
+                }
+                
+                //do a sanity check before executing the command
+                if ((!result->help_flag) &&
+                    modes[system_config.mode].protocol_preflight_sanity_check
+                ) { 
+                    // BUGBUG -- This was IGNORING the preflight check result!!!
+                    // true == everything is OK
+                    if (!(modes[system_config.mode].protocol_preflight_sanity_check())) {
+                        printf("%s\r\n", "preflight check failed");
+                        result->error   = true;
+                        result->success = false;
+                        return true;
+                    }
+                }
+                bool suppress_fala = modes[system_config.mode].mode_commands[user_cmd_id].supress_fala_capture;
+                if (!suppress_fala) { // start FALA if not suppressed
+                    fala_start_hook();
+                }
+
+                // execute the mode command ... which sets result
+                modes[system_config.mode].mode_commands[user_cmd_id].func(result);
+                
+                if (!suppress_fala) { //stop FALA
+                    fala_stop_hook();
+                    fala_notify_hook();
+                }
+                return true;
+            }
+        }
+    }
+
+    // no such command, search storage for runnable scripts?
+
+    // This calls into the display command handler, if it exists?
+    if (displays[system_config.display].display_command) {
+        if (displays[system_config.display].display_command(result)) {
+            return true; // rely on the command itself to set result values
+        }
+    }
+    // if nothing so far, hand off to mode parser
+    if (modes[system_config.mode].protocol_command) {
+        if (modes[system_config.mode].protocol_command(result)) {
+            return true; // rely on the command itself to set result values
+        }
+    }
+
+    // error no such command
+    PRINT_WARNING("Command `%s` not found\r\n", command_string);
+    printf("%s", ui_term_color_notice());
+    printf(GET_T(T_CMDLN_INVALID_COMMAND), command_string);
+    printf("%s\r\n", ui_term_color_reset());
+    return true;
+
+}
+bool ui_process_commands_new(void) {
+    struct _command_info_t cp = {0};
+    cp.nextptr = 0;
+
+    while (true) {
+        if (!cmdln_find_next_command(&cp)) {
+            return false;
+        }
+
+        struct command_result result = result_blank;
+        // pass current offsets for command,
+        // request result structure be filled in
+        bool cmd_ok = ui_process_single_command_impl(&cp, &result);
+        if (!cmd_ok) {
+            return false; // syntax error causes end of parsing this command line
+        }
+
+        printf("%s\r\n", ui_term_color_reset());
+        switch (cp.delimiter) // next action based on the command delimiter
+        {
+            case 0:
+                // No delimiter, so no chained commands
+                return false; // done
+            case ';':
+                // semicolon, so unconditionally execute the next command
+                break;
+            case '|':
+                // `||`, so only chain to next command if the current command failed
+                if (!result.error) {
+                    return false;
+                }
+                break;
+            case '&':
+                // `&&`, so only chain to next command if the current command succeeded
+                if (result.error) {
+                    return false;
+                }
+                break; // perform next if last success
+            default:
+                PRINT_FATAL("Internal error: Unexpected command delimited `%c` (0x%02X)\r\n",
+                            cp.delimiter, cp.delimiter);
+                return false;
+        }
+    } // end of while loop ... should never get past here.
+    PRINT_FATAL("Internal error: Unexpected exit of while(1) loop\r\n");
+    return false;
+}
+
+

--- a/src/ui/ui_process.c
+++ b/src/ui/ui_process.c
@@ -27,13 +27,14 @@
 // const structs are init'd with 0s, we'll make them here and copy in the main loop
 static const struct command_result result_blank;
 
-SYNTAX_STATUS ui_process_syntax(void) {
+bool ui_process_syntax_ex(command_line_history_t* history) {
 
+    // BUGBUG -- This IGNORES failures in the preflight check ... so what's the point?
     if(modes[system_config.mode].protocol_preflight_sanity_check){
         modes[system_config.mode].protocol_preflight_sanity_check();
     }
 
-    SYNTAX_STATUS result = syntax_compile();
+    SYNTAX_STATUS result = syntax_compile_ex(history);
     if (result !=SSTATUS_OK) {
         printf("Syntax compile error\r\n");
         return result;
@@ -67,6 +68,9 @@ SYNTAX_STATUS ui_process_syntax(void) {
     fala_notify_hook();
 
     return result;
+}
+SYNTAX_STATUS ui_process_syntax(void) { // TODO: deprecate this function, use ui_process_syntax_ex() instead
+    return ui_process_syntax_ex(&cmdln);
 }
 
 bool ui_process_macro(void) {

--- a/src/ui/ui_process.c
+++ b/src/ui/ui_process.c
@@ -88,8 +88,8 @@ bool ui_process_macro(void) {
 
 //returns error = true or false
 bool ui_process_commands(void) {
-    struct _command_info_t cp = {0};
-    cp.nextptr = 0;
+    command_info_t cp;
+    cmdln_init_command_info(&cmdln, &cp);
 
     while (true) {
         if (!cmdln_find_next_command(&cp)) {
@@ -251,7 +251,7 @@ bool ui_process_commands(void) {
 // return TRUE if command was processed, and should
 // consider chaining
 // TODO: Split this into functions for each type: global, mode, display, 
-bool ui_process_single_command_impl(struct _command_info_t const * cp, struct command_result * result) {
+bool ui_process_single_command_impl(command_info_t const * cp, struct command_result * result) {
 
     memcpy(&result, &result_blank, sizeof(struct command_result));
 
@@ -390,8 +390,8 @@ bool ui_process_single_command_impl(struct _command_info_t const * cp, struct co
 
 }
 bool ui_process_commands_new(void) {
-    struct _command_info_t cp = {0};
-    cp.nextptr = 0;
+    command_info_t cp;
+    cmdln_init_command_info(&cmdln, &cp);
 
     while (true) {
         if (!cmdln_find_next_command(&cp)) {

--- a/src/ui/ui_process.c
+++ b/src/ui/ui_process.c
@@ -90,6 +90,7 @@ bool ui_process_commands(void) {
             return false;
         }
 
+        // Special-case: these prefixes don't require space before the first argument, so only check first character is a match
         switch (cp.command[0]) {
             case '[':
             case '>':
@@ -102,13 +103,16 @@ bool ui_process_commands(void) {
                 return ui_process_macro(); // first character is (, mode macro
                 break;
         }
+
         // process as a command
         char command_string[MAX_COMMAND_LENGTH];
         struct command_result result = result_blank;
         // string 0 is the command
-        //  continue if we don't get anything? could be an empty chained command? should that be error?
+        // continue if we don't get anything? could be an empty chained command? should that be error?
         if (!cmdln_args_string_by_position(0, sizeof(command_string), command_string)) {
-            continue;
+            result.error = false;
+            result.success = true;
+            goto cmd_ok;
         }
 
         enum COMMAND_TYPE {

--- a/src/ui/ui_process.h
+++ b/src/ui/ui_process.h
@@ -1,3 +1,9 @@
+#pragma once
+
+#include <ui/ui_cmdln.h>
+
+bool ui_process_syntax_ex(command_line_history_t* command_history_buffer);
+
 
 bool ui_process_commands(void);
 bool ui_process_syntax(void);

--- a/src/ui/ui_prompt.c
+++ b/src/ui/ui_prompt.c
@@ -1,3 +1,6 @@
+#define BP_DEBUG_OVERRIDE_DEFAULT_CATEGORY BP_DEBUG_CAT_CMDLINE_PARSER
+#define BP_NO_LEGACY_CMDLINE_FUNCTIONS
+
 #include <stdbool.h>
 #include <stdio.h>
 #include "pico/stdlib.h"
@@ -105,13 +108,13 @@ bool ui_prompt_prompt_bio_pin(const struct ui_prompt* menu) {
 // used internally in ui_prompt
 // gets user input until <enter> or return false if system error
 bool ui_prompt_user_input(void) {
-    cmdln_next_buf_pos(); // flush all input
+    cmdln_next_buf_pos_ex(&cmdln); // flush all input
     do {
         if (system_config.error) {
             return false;
         }
     } while (ui_term_get_user_input() != 0xff);
-    ui_parse_consume_whitespace();
+    ui_parse_consume_whitespace_ex(&cmdln);
     return true;
 }
 
@@ -129,7 +132,7 @@ bool ui_prompt_bool(prompt_result* result, bool defval_show, bool defval, bool a
             return false;
         }
 
-        ui_parse_get_bool(result, user_value);
+        ui_parse_get_bool_ex(&cmdln, result, user_value);
 
         printf("\r\n");
 
@@ -175,7 +178,7 @@ bool ui_prompt_uint32(prompt_result* result, const struct ui_prompt* menu, uint3
             return false;
         }
 
-        ui_parse_get_uint32(result, value);
+        ui_parse_get_uint32_ex(&cmdln, result, value);
 
         if ((*menu).config->allow_exit && result->exit) {
             return false;
@@ -212,7 +215,7 @@ bool ui_prompt_float(
             return false;
         }
 
-        ui_parse_get_float(result, user_value);
+        ui_parse_get_float_ex(&cmdln, result, user_value);
 
         printf("\r\n");
 
@@ -243,7 +246,7 @@ bool ui_prompt_float_units(prompt_result* result, const char* menu, float* user_
             return false;
         }
 
-        ui_parse_get_float(result, user_value);
+        ui_parse_get_float_ex(&cmdln, result, user_value);
 
         if (result->exit) {
             return true;
@@ -252,7 +255,7 @@ bool ui_prompt_float_units(prompt_result* result, const char* menu, float* user_
         // get the trailing type
         char units[4] = { 0, 0, 0, 0 };
 
-        if (ui_parse_get_units(result, units, 4, user_units)) {
+        if (ui_parse_get_units_ex(&cmdln, result, units, 4, user_units)) {
             return true;
         }
 
@@ -320,7 +323,7 @@ bool ui_prompt_vt100_mode(prompt_result* result, uint32_t* value) {
         return false;
     }
 
-    if (!cmdln_try_remove(&c)) {
+    if (!cmdln_try_remove_ex(&cmdln, &c)) {
         return false;
     }
 
@@ -337,7 +340,7 @@ bool ui_prompt_vt100_mode(prompt_result* result, uint32_t* value) {
             break;
     }
 
-    cmdln_next_buf_pos();
+    cmdln_next_buf_pos_ex(&cmdln);
 
     return true;
 }
@@ -349,11 +352,11 @@ uint32_t ui_prompt_yes_no(void) {
         return 2;
     }
 
-    if (!cmdln_try_remove(&c)) {
+    if (!cmdln_try_remove_ex(&cmdln, &c)) {
         return 2;
     }
 
-    cmdln_next_buf_pos();
+    cmdln_next_buf_pos_ex(&cmdln);
 
     c |= 0x20; // to lowercase
 

--- a/src/ui/ui_prompt.h
+++ b/src/ui/ui_prompt.h
@@ -24,6 +24,7 @@ typedef struct ui_prompt_config {
     bool (*menu_validate)(const struct ui_prompt* menu, uint32_t* value);
 } ui_prompt_config;
 
+// TODO: Document valid result data combinations, and what those combinations **_mean_**.
 typedef struct prompt_result {
     uint8_t number_format;
     bool success;

--- a/src/ui/ui_term.c
+++ b/src/ui/ui_term.c
@@ -558,17 +558,17 @@ void ui_term_cmdln_arrow_keys(char* c) {
             }
             break;
         case 'A': // up
-            cmdln.histptr++;
-            if (!ui_term_cmdln_history(cmdln.histptr)) // on error restore ptr and ring a bell
+            cmdln.which_history++;
+            if (!ui_term_cmdln_history(cmdln.which_history)) // on error restore ptr and ring a bell
             {
-                cmdln.histptr--;
+                cmdln.which_history--;
                 printf("\x07");
             }
             break;
         case 'B': // down
-            cmdln.histptr--;
-            if ((cmdln.histptr < 1) || (!ui_term_cmdln_history(cmdln.histptr))) {
-                cmdln.histptr = 0;
+            cmdln.which_history--;
+            if ((cmdln.which_history < 1) || (!ui_term_cmdln_history(cmdln.which_history))) {
+                cmdln.which_history = 0;
                 printf("\x07");
             }
             break;
@@ -616,6 +616,10 @@ void ui_term_cmdln_arrow_keys(char* c) {
 }
 
 // copies a previous cmd to current position int ui_cmdbuff
+// TODO: make prev / next functions instead, returning
+//       a boolean to indicate success (true) or failure (false)
+//       this will encapsulate the `which_history` logic into a
+//       single function (which is good).
 int ui_term_cmdln_history(int ptr) {
     int i;
     uint32_t temp;


### PR DESCRIPTION
Already addressed:

* Add support for `#` to comment out the remainder of the line of input.
* Comments are output via RTT (allows more easily correlating debug output with scripts, for example).
* Flag (and then fix) some of the newly discovered issues with command line parsing.
* Rename command line parsing structures and fields to more clearly align with use.

TODO:
* [ ] Make **command history more reliable**
    * [ ] Remove globals ... all APIs to transition to explicit buffers, etc.
        * [ ]  `cmdln` and `command_info` in `src/ui/ui_cmdln.c`
    * [ ] Use **distinct buffer** for running scripts and prompts
        * [ ] may need to rewrite functions to not presume using the global variables
        * [ ] existing API will become wrapper that uses the global variables
        * [ ] see, for example, `exec_macro_id()` function in `src/commands/global/macro`
        * [ ] see, for example, `ui_prompt_user_input()` function
        * [ ] also need to change `ui_term_get_user_input()` to indicate which buffer to use
* [ ] Allow strings to be quoted (allowing embedded spaces, etc.)
    * [ ] within quoted string, support for escaped backslash character `\\`
    * [ ] within quoted string, support for escaped quote character `\"`
    * [ ] within quoted string, support for arbitrary encoded bytes `\xHH`, where `H` is a hexdigit
    * [ ] API to return quoted strings without the enclosing quotes, and escaped bytes un-escaped
* [ ] BUGFIX - flags should be preceded only by whitespace
    * [ ] E.g., `foo -v 100` is a valid command `foo` with flag `v` which has a value
    * [ ] E.g., `foo '-v' 100` should be rejected as an invalid command (_current code sees this as a valid flag(!)_)
    * [ ] E.g., `foo --v 100` should be rejected as an invalid command (_current code sees this as a valid flag(!)_)
* [ ] Update API names to differentiate between entire history, current line of input, and current command
* [ ] Update API parameters to name what offsets are relative to ... entire history, current line, or current command
* [ ] Define a set of **test inputs** that exercises relevant code paths
    * [ ]  Even if just abuse comment handler for now
* [ ] **Rotate** command line history so that current command always starts at offset zero
    * [ ] Rotate the buffer and set read/write offsets
    * [ ] Make all history items "safe" for use
    * [ ] Zero unused space from new write offset to oldest usable history item
* [ ] Encapsulate applying history items (via up/down arrow keys typically) into helper functions (hide history count variable)
* [ ] After "rotate" feature is done, simpify the code!
    * [ ] Strings will be guaranteed to be contiguous for a given command line (current or history)
    * [ ] Start offset will be guaranteed to be less than the end offset
    * [ ] Life just becomes happier!
* [ ] Fix all newly discovered issues

